### PR TITLE
Login fails when User has non alphanumerical characters in distinguishedName

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -31,6 +31,8 @@ import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 /**
  * {@link AuthenticationProvider} with Active Directory, through LDAP.
  * 
@@ -218,7 +220,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                 }
             }
 
-            Set<GrantedAuthority> groups = resolveGroups(domainDN, dn.toString(), context);
+            Set<GrantedAuthority> groups = resolveGroups(domainDN, StringEscapeUtils.escapeJava(dn.toString()), context);
             groups.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
 
             return new ActiveDirectoryUserDetail(id, password, true, true, true, true, groups.toArray(new GrantedAuthority[groups.size()]),


### PR DESCRIPTION
Fixes an issue where a user with non-alphanumeric characters in their distinguishedName causes an error.

Also thanks for the plugin!
