### PR TITLE
Moved time-consuming operations from toString to setAuthorities

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUserDetail.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUserDetail.java
@@ -17,6 +17,8 @@ public class ActiveDirectoryUserDetail extends User {
     // additional attributes from Active Directory
     private final String displayName, mail, telephoneNumber;
 
+    private String toStringValue;
+
 	public ActiveDirectoryUserDetail(String username, String password,
 			boolean enabled, boolean accountNonExpired,
 			boolean credentialsNonExpired, boolean accountNonLocked,
@@ -44,6 +46,39 @@ public class ActiveDirectoryUserDetail extends User {
 
     public String getTelephoneNumber() {
         return telephoneNumber;
+    }
+
+    @Override
+    public String toString() {
+        return toStringValue;
+    }
+
+    @Override
+    protected void setAuthorities(GrantedAuthority[] authorities) {
+        super.setAuthorities(authorities);
+        StringBuffer sb = new StringBuffer();
+        sb.append(super.toString()).append(": ");
+        sb.append("Username: ").append(getUsername()).append("; ");
+        sb.append("Password: [PROTECTED]; ");
+        sb.append("Enabled: ").append(isEnabled()).append("; ");
+        sb.append("AccountNonExpired: ").append(isAccountNonExpired()).append("; ");
+        sb.append("credentialsNonExpired: ").append(isCredentialsNonExpired()).append("; ");
+        sb.append("AccountNonLocked: ").append(isAccountNonLocked()).append("; ");
+
+        if (this.getAuthorities() != null) {
+            sb.append("Granted Authorities: ");
+
+            for (int i = 0; i < this.getAuthorities().length; i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+
+                sb.append(this.getAuthorities()[i].toString());
+            }
+        } else {
+            sb.append("Not granted any authorities");
+        }
+        toStringValue = sb.toString();
     }
 
     public static long getSerialVersionUID() {


### PR DESCRIPTION
The toString method is called lots of times whenever the permissions
of a user is to be checked. Every toString call will create a
concatenated string of all the groups the user is part of. I have
moved this concatenation to the setAuthorities method, which will
cause it to be run on login instead of every time a user needs
permissions for anything. Big performance gains have been seen at
the low cost of having to re-log if a relevant change is made in
the users permissions.
