### PR TITLE
Make test-button work for multidomain configurations

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -308,7 +308,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                             DirContext context = bind(bindName, Secret.toString(password), servers);
                             try {
                                 // actually do a search to make sure the credential is valid
-                                new LDAPSearchBuilder(context, toDC(domain)).searchOne("(objectClass=user)");
+                                new LDAPSearchBuilder(context, toDC(name)).searchOne("(objectClass=user)");
                             } finally {
                                 context.close();
                             }


### PR DESCRIPTION
When validating the configuration, the domain is split at ',' and
each part will be validated individually. However, the actually bind
will use the original domain string with ',' which doesn't work.

Unfortunately, I no longer have access to a Jenkins instance with
multiple domain servers, so this is untested.
