### PR TITLE
[JENKINS-21073] Fix forceLdaps system property

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -621,5 +621,5 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
      * One legitimate use case is when the domain controller is Windows 2000, which doesn't support TLS
      * (according to http://support.microsoft.com/kb/321051).
      */
-    public static boolean FORCE_LDAPS = Boolean.getBoolean(ActiveDirectoryUnixAuthenticationProvider.class.getName()+".forceLdaps");
+    public static boolean FORCE_LDAPS = Boolean.getBoolean(ActiveDirectorySecurityRealm.class.getName()+".forceLdaps");
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-21073

The [active directory plugin documentation](https://wiki.jenkins-ci.org/display/JENKINS/Active+Directory+plugin#ActiveDirectoryplugin-SecuringaccesstoActiveDirectoryservers) suggests setting `hudson.plugins.active_directory.ActiveDirectorySecurityRealm.forceLdaps` to force connecting via LDAPS.  This fixes two bugs:
- Updates the code to use the correct system property
- Changes the default LDAPS port from 686 to 636 (see http://support.microsoft.com/kb/321051/en-us)

I understand that STARTTLS is the preferred method, but that isn't working for me (not sure why).  LDAPS works, and this makes it a little easier to use.
