### PR TITLE
Disable the Active Directory Groups on Unix

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -100,6 +100,8 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     public final String bindName;
 
     public final Secret bindPassword;
+    
+    public final boolean isGroupRetrievingDisabled;
 
     /**
      * If non-null, Jenkins will try to connect at this server at the first priority, before falling back to
@@ -108,11 +110,12 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     public final String server;
 
     @DataBoundConstructor
-    public ActiveDirectorySecurityRealm(String domain, String site, String bindName, String bindPassword, String server) {
+    public ActiveDirectorySecurityRealm(String domain, String site, String bindName, String bindPassword, String server, boolean isGroupRetrievingDisabled) {
         this.domain = fixEmpty(domain);
         this.site = fixEmpty(site);
         this.bindName = fixEmpty(bindName);
         this.bindPassword = Secret.fromString(fixEmpty(bindPassword));
+        this.isGroupRetrievingDisabled = isGroupRetrievingDisabled;
 
         // append default port if not specified
         server = fixEmpty(server);

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -53,6 +53,8 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
     private final String server;
 
     private final String bindName, bindPassword;
+    
+    private final boolean isGroupRetrievingDisabled;
 
     private final ActiveDirectorySecurityRealm.DescriptorImpl descriptor;
 
@@ -120,6 +122,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
         this.site = realm.site;
         this.bindName = realm.bindName;
         this.server = realm.server;
+        this.isGroupRetrievingDisabled = realm.isGroupRetrievingDisabled;
         this.bindPassword = Secret.toString(realm.bindPassword);
         this.descriptor = realm.getDescriptor();
     }
@@ -290,7 +293,10 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                 }
             }
 
-            Set<GrantedAuthority> groups = resolveGroups(domainDN, dn.toString(), context);
+            Set<GrantedAuthority> groups = new HashSet<GrantedAuthority>();
+            if ( !this.isGroupRetrievingDisabled ) {
+                groups = resolveGroups(domainDN, dn.toString(), context);
+            }
             groups.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
 
             return new ActiveDirectoryUserDetail(id, password, true, true, true, true, groups.toArray(new GrantedAuthority[groups.size()]),

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/config.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/config.jelly
@@ -17,6 +17,9 @@
         <f:entry field="bindPassword" title="${%Bind Password}">
           <f:password />
         </f:entry>
+        <f:entry title="${%Disable groups retrieving}" field="isGroupRetrievingDisabled">
+           <f:checkbox/>
+        </f:entry> 
       </f:advanced>
       <f:nested>
         <f:validateButton with="domain,site,bindName,bindPassword,server" title="${%Test}" method="validate"/>


### PR DESCRIPTION
This patch allow the end-user to disable the retrieving of groups from the Active Directory on Linux, directly from Security Configuration on Jenkins.