### PR TITLE
[FIXED JENKINS-26737] AD can not log on with email address

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -369,16 +369,16 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
     /**
      * Returns the full user principal name of the form "joe@europe.contoso.com".
      * 
-     * If people type in 'foo@bar' or 'bar\\foo', it should be treated as
-     * 'foo@bar.acme.org' (where 'acme.org' part comes from the given domain name)
+     * If people type in 'foo@bar' or 'bar\foo' or just 'foo', it should be treated as
+     * 'foo@bar' (where 'bar' represents the given domain name)
      */
     private String getPrincipalName(String username, String domainName) {
         String principalName;
         int slash = username.indexOf('\\');
         if (slash>0) {
-            principalName = username.substring(slash+1)+'@'+username.substring(0, slash)+'.'+domainName;
+            principalName = username.substring(slash+1)+'@'+domainName;
         } else if (username.contains("@"))
-            principalName = username+'.'+domainName;
+            principalName = username;
         else
             principalName = username+'@'+domainName;
         return principalName;


### PR DESCRIPTION
Whenever someone tries to login with upn (someone@domain.com) the domain was appended to the username, this is unnecessary because the domain is already included in the upn.