### PR TITLE
Fixing open issue JENKINS-29280 which autofills passwords

### DIFF
--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
@@ -22,4 +22,10 @@
   <f:nested>
     <f:validateButton with="domain,server,site,bindName,bindPassword" title="${%Test}" method="validate"/>
   </f:nested>
+	<script type="text/javascript" >
+		document.addEventListener("DOMContentLoaded", function(event) {
+		   document.getElementsByName("_.bindPassword")[0].autocomplete = "off";
+		   document.getElementsByName("_.bindName")[0].autocomplete = "off";
+		});
+	</script>
 </j:jelly>


### PR DESCRIPTION
Fixing this open bug https://issues.jenkins-ci.org/browse/JENKINS-29280

I could not find a simple Jelly solution to set the autocomplete attributes. Instead using a JS workaround to attach the autocomplete attribute after the page is loaded.