### PR TITLE
Ensure a password is provided

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
@@ -104,7 +104,7 @@ public class ActiveDirectoryAuthenticationProvider extends AbstractActiveDirecto
         if(authentication!=null)
             password = (String) authentication.getCredentials();
 
-        // We need to check a password is provided to prevent an annonymous bin
+        // We need to check a password is provided to prevent an annonymous bind
         // See https://tools.ietf.org/html/rfc4513#section-5.1.2 for more details.
         if(password == null || password.isEmpty()) {
             String msg = String.format("No password provided for %s", username);

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
@@ -104,6 +104,14 @@ public class ActiveDirectoryAuthenticationProvider extends AbstractActiveDirecto
         if(authentication!=null)
             password = (String) authentication.getCredentials();
 
+        // We need to check a password is provided to prevent an annonymous bin
+        // See https://tools.ietf.org/html/rfc4513#section-5.1.2 for more details.
+        if(password == null || password.isEmpty()) {
+            String msg = String.format("No password provided for %s", username);
+            LOGGER.log(Level.FINE, "Login failure: "+msg);
+            throw (BadCredentialsException)new BadCredentialsException(msg);
+        }
+
         String dn = getDnOfUserOrGroup(username);
 
         ComObjectCollector col = new ComObjectCollector();


### PR DESCRIPTION
If the Active Directory server has anonymous bind enabled it is possible to login simply by providing a valid username.

According to [rfc4513](https://tools.ietf.org/html/rfc4513#section-5.1.2) it is the responsibility of the client to check that a password is provided.

> Unauthenticated Bind operations can have significant security issues
   (see Section 6.3.1).  In particular, users intending to perform
   Name/Password Authentication may inadvertently provide an empty
   password and thus cause poorly implemented clients to request
   Unauthenticated access.  Clients SHOULD be implemented to require
   user selection of the Unauthenticated Authentication Mechanism by
   means other than user input of an empty password.  **Clients SHOULD
   disallow an empty password input to a Name/Password Authentication
   user interface.**  Additionally, Servers SHOULD by default fail
   Unauthenticated Bind requests with a resultCode of
   unwillingToPerform.

*(emphasis added)*