### PR TITLE
[JENKINS-31575] Adding SSO/Client certificate authentication against

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532</version>
+    <version>1.554</version>
   </parent>
 
   <artifactId>active-directory</artifactId>
@@ -109,4 +109,3 @@
     </license>
   </licenses>
 </project>
-

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
@@ -68,7 +68,8 @@ public class ActiveDirectoryAuthenticationProvider extends AbstractActiveDirecto
      */
     private final _Connection con;
 
-    public ActiveDirectoryAuthenticationProvider() throws IOException {
+    public ActiveDirectoryAuthenticationProvider(ActiveDirectorySecurityRealm realm) throws IOException {
+        super(realm);
         try {
             IADs rootDSE = COM4J.getObject(IADs.class, "LDAP://RootDSE", null);
 
@@ -223,7 +224,8 @@ public class ActiveDirectoryAuthenticationProvider extends AbstractActiveDirecto
 		return dn;
 	}
 
-	public GroupDetails loadGroupByGroupname(String groupname) {
+	@Override
+  public GroupDetails retrieveGroup(String groupname) {
         ActiveDirectoryGroupDetails details = groupCache.get(groupname);
         if (details!=null)      return details;
         throw new UsernameNotFoundException("Group not found: " + groupname);

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -32,6 +32,7 @@ import hudson.Functions;
 import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+import hudson.plugins.active_directory.sso.SSOOptions;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.GroupDetails;
@@ -92,7 +93,15 @@ import static hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationP
  * @author Kohsuke Kawaguchi
  */
 public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityRealm {
-    /**
+  private final SSOOptions ssoOptions;
+  /**
+   * Is SSO Enabled
+   */
+  public SSOOptions getSsoOptions() {
+      return this.ssoOptions;
+  }
+
+  /**
      * Active directory domain name to authenticate against.
      * 
      * <p>
@@ -152,13 +161,13 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
 
     public ActiveDirectorySecurityRealm(String domain, String site, String bindName,
                                         String bindPassword, String server, GroupLookupStrategy groupLookupStrategy, boolean removeIrrelevantGroups) {
-        this(domain,site,bindName,bindPassword,server,groupLookupStrategy,removeIrrelevantGroups,domain!=null);
+        this(domain,site,bindName,bindPassword,server,groupLookupStrategy,removeIrrelevantGroups,domain!=null,null);
     }
     
     @DataBoundConstructor
     // as Java signature, this binding doesn't make sense, so please don't use this constructor
     public ActiveDirectorySecurityRealm(String domain, String site, String bindName,
-                                        String bindPassword, String server, GroupLookupStrategy groupLookupStrategy, boolean removeIrrelevantGroups, Boolean customDomain) {
+                                        String bindPassword, String server, GroupLookupStrategy groupLookupStrategy, boolean removeIrrelevantGroups, Boolean customDomain, SSOOptions ssoOptions) {
         if (customDomain!=null && !customDomain)
             domain = null;
         this.domain = fixEmpty(domain);
@@ -175,6 +184,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
         }
 
         this.server = server;
+        this.ssoOptions=ssoOptions;
     }
 
     public GroupLookupStrategy getGroupLookupStrategy() {
@@ -324,7 +334,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                     // this check must be identical to that of ActiveDirectory.groovy
                     try {
                         // make sure we can connect via ADSI
-                        new ActiveDirectoryAuthenticationProvider();
+                        new ActiveDirectoryAuthenticationProvider(null);
                         return FormValidation.ok("OK");
                     } catch (Exception e) {
                         return FormValidation.error(e, "Failed to contact Active Directory");

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -141,6 +141,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
     };
     
     public ActiveDirectoryUnixAuthenticationProvider(ActiveDirectorySecurityRealm realm) {
+        super(realm);
         if (realm.domain==null) throw new IllegalArgumentException("Active Directory domain name is required but it is not set");
         this.domainNames = realm.domain.split(",");
         this.site = realm.site;
@@ -339,7 +340,8 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
         }
     }
 
-    public GroupDetails loadGroupByGroupname(String groupname) {
+    @Override
+    public GroupDetails retrieveGroup(String groupname) {
         if (bindName==null)
             throw new UserMayOrMayNotExistException("Unable to retrieve group information without bind DN/password configured");
 

--- a/src/main/java/hudson/plugins/active_directory/sso/SSOFilter.java
+++ b/src/main/java/hudson/plugins/active_directory/sso/SSOFilter.java
@@ -1,0 +1,171 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2008-2015, Louis Lecaroz, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.active_directory.sso;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.cert.X509Certificate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.acegisecurity.Authentication;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.GrantedAuthorityImpl;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.acegisecurity.ui.WebAuthenticationDetails;
+import org.acegisecurity.userdetails.User;
+import org.acegisecurity.userdetails.UserDetails;
+
+import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
+import hudson.plugins.active_directory.ActiveDirectoryUserDetail;
+import hudson.security.SecurityRealm;
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
+import jenkins.security.SecurityListener;
+
+public class SSOFilter implements Filter {
+  static final Logger LOGGER = Logger.getLogger(SSOFilter.class.getName());
+
+  /**
+   * Tests if username is the one in the current authentication
+   * 
+   * @param a Authentication instance containing all current authentication data coming from context
+   * @param   username username to be compared to
+   * @return  true if equal otherwise false
+   */
+  private boolean isUsername(Authentication a, String username) {
+    // Check first if current principal is a ActiveDirectoryUserDetail and compare to its username otherwise against the authentication getname()
+    if( username!=null && a!=null) {
+      final Object principal=a.getPrincipal();
+      if(principal instanceof ActiveDirectoryUserDetail) return username.equals(((ActiveDirectoryUserDetail)principal).getUsername());
+      else return username.equals(a.getName());
+    }
+    return false;
+  }
+
+  @Override
+  public void destroy()
+  {      
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    final SecurityRealm realm = Jenkins.getInstance().getSecurityRealm();
+    final X509Certificate[] certChain = (X509Certificate[])request.getAttribute("javax.servlet.request.X509Certificate");
+    final Authentication oldAuthentication=SecurityContextHolder.getContext().getAuthentication();
+    final Authentication a;
+    
+    if (
+          (!(request instanceof HttpServletRequest) || !(response instanceof  HttpServletResponse)) || // Must be an HTTP Call
+          !(certChain != null && certChain.length>0 && certChain[0] != null ) || // Must contain a certificate
+          !(realm instanceof ActiveDirectorySecurityRealm  && ((ActiveDirectorySecurityRealm)realm).getSsoOptions()!=null && ((ActiveDirectorySecurityRealm)realm).getSsoOptions().getUserField()!=null) // SSO must be enabled and the user field must be not null
+    ) {
+      chain.doFilter(request, response);
+      return;
+    }
+    
+    final ActiveDirectorySecurityRealm activeDirectoryRealm = (ActiveDirectorySecurityRealm)realm;
+    final String dn = certChain[0].getSubjectDN()!=null?certChain[0].getSubjectDN().getName():null;
+    final String[] splittedDn = dn!=null?dn.split(activeDirectoryRealm.getSsoOptions().getUserField() + "="):null;
+    
+    String username = (splittedDn!=null && splittedDn.length>1)?splittedDn[1].split(",")[0]:null;
+    
+    if(username==null || username.isEmpty()) { // A username must be found in the certifcate regarding the userField X500 syntax
+      LOGGER.warning("User authentication failed: No username found in certificate: "+dn);
+      chain.doFilter(request, response);
+      return;
+    }
+
+    final String group = activeDirectoryRealm.getSsoOptions().getDefaultGroup();    
+    // Checking rules, no change, lower or upper case
+    if(SSOOptions.SSO_MODE_LOWER.equalsIgnoreCase(activeDirectoryRealm.getSsoOptions().getCheckMode())) username=username.toLowerCase();
+    else if(SSOOptions.SSO_MODE_UPPER.equalsIgnoreCase(activeDirectoryRealm.getSsoOptions().getCheckMode())) username=username.toUpperCase();
+    
+    if(!SSOOptions.SSO_MODE_NOCHECK.equalsIgnoreCase(activeDirectoryRealm.getSsoOptions().getCheckMode())) { // Client certificate must be checked against AD
+      LOGGER.log(Level.FINE, "Checking against AD for: {0}", username);
+      if(!isUsername(oldAuthentication,username)) { // The current authenticated user is not the one having the current client certificate
+        UserDetails d=null;
+        try { // To work correctly if an exception is generated by loadUserByUsername, it should not throw the exception and continue chaining to the original AD filter, otherwise it will be oddly logged with another account !
+          d=activeDirectoryRealm.getAuthenticationProvider().loadUserByUsername(username);
+        } catch(Exception e) {
+          LOGGER.log(Level.SEVERE,e.getMessage(),e);
+        }
+        if(d!=null && username.equals(d.getUsername())) // Ensure that returned user details from AD is for the current one                                                   
+          a = new UsernamePasswordAuthenticationToken(d, null, d.getAuthorities());
+        else a=null; // an error ? force to be authenticated with the standard page                          
+      } else a=oldAuthentication; 
+    } else { // no_check against AD set, create the data users for allowing it
+      username+=(activeDirectoryRealm.getSsoOptions().getJenkinsUsernameSuffix()!=null?activeDirectoryRealm.getSsoOptions().getJenkinsUsernameSuffix():"");
+      LOGGER.log(Level.FINE, "Only certificate authentication for: {0}", username);
+     if(!isUsername(oldAuthentication,username)) {
+        final GrantedAuthority[] authorities = new GrantedAuthority[] {
+            SecurityRealm.AUTHENTICATED_AUTHORITY,
+            new GrantedAuthorityImpl(group!=null && !group.isEmpty()?group:"")
+          };    
+        a = new UsernamePasswordAuthenticationToken(new ActiveDirectoryUserDetail(username, null, true, true, true, true, authorities, username, null, null), null, authorities);
+      }
+      else a=null;
+    }
+
+    if(a!=null && a!=oldAuthentication) { // User authenticated with a certificate, set it and go to the next filter instead of using the original one used by AD (if secContext is null,a will be null also) 
+      ((UsernamePasswordAuthenticationToken)a).setDetails(new WebAuthenticationDetails((HttpServletRequest) request)); 
+      SecurityContextHolder.getContext().setAuthentication(a); // Set this authenticated in the newly created security context
+      if(Jenkins.getVersion().isNewerThan(new VersionNumber("1.568"))) {
+        try {
+          Method fireLoggedIn = SecurityListener.class.getMethod("fireLoggedIn", String.class);
+          if(fireLoggedIn!=null && a.getPrincipal() instanceof User) fireLoggedIn.invoke(null, ((User)a.getPrincipal()).getUsername());
+        } catch(NoSuchMethodException e) {}
+        catch (IllegalAccessException e) {
+          LOGGER.log(Level.SEVERE,e.getMessage(),e);
+        }
+        catch (IllegalArgumentException e) {
+          LOGGER.log(Level.SEVERE,e.getMessage(),e);
+        }
+        catch (InvocationTargetException e) {
+          LOGGER.log(Level.SEVERE,e.getMessage(),e);
+        }
+      }
+      LOGGER.log(Level.FINE, "Authenticated user {0}", ((User)a.getPrincipal()).getUsername());
+    }
+    chain.doFilter( request, response);
+  }
+
+  @Override
+  public void init(FilterConfig arg0) throws ServletException
+  {
+    
+  }
+  
+}

--- a/src/main/java/hudson/plugins/active_directory/sso/SSOOptions.java
+++ b/src/main/java/hudson/plugins/active_directory/sso/SSOOptions.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2008-2015, Louis Lecaroz, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.active_directory.sso;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class SSOOptions {
+  public final static String SSO_MODE_NOCHECK="no_check";
+  public final static String SSO_MODE_LOWER="lower";
+  public final static String SSO_MODE_UPPER="upper";
+  
+  private final String userField;
+  private final String defaultGroup;
+  private final String checkMode;
+  private final String jenkinsUsernameSuffix;
+  
+  public String getJenkinsUsernameSuffix() {
+    return jenkinsUsernameSuffix;
+  }
+
+  /**
+   * Field of the DN to look at.
+   */
+  public String getUserField() {
+      return this.userField;
+  }
+
+  /**
+   * Field of the Sso Case mode to be converted in another case
+   */
+  public String getCheckMode() {
+      return this.checkMode;
+  }
+  
+  public String getDefaultGroup() {
+    return this.defaultGroup;
+  }
+  
+
+  @DataBoundConstructor
+  public SSOOptions(final String userField, final String defaultGroup, final String checkMode,final String jenkinsUsernameSuffix) {
+    this.userField=userField;
+    this.checkMode=checkMode;
+    this.jenkinsUsernameSuffix=jenkinsUsernameSuffix;
+    this.defaultGroup=defaultGroup;
+  }
+}

--- a/src/main/java/hudson/plugins/active_directory/sso/SSOPluginImpl.java
+++ b/src/main/java/hudson/plugins/active_directory/sso/SSOPluginImpl.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2008-2015, Louis Lecaroz, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.active_directory.sso;
+
+import hudson.Extension;
+import hudson.Plugin;
+import hudson.tasks.PluginImpl;
+import hudson.util.PluginServletFilter;
+import jenkins.model.Jenkins;
+
+import javax.servlet.ServletException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.Filter;
+
+
+@Extension 
+public class SSOPluginImpl  extends Plugin 
+{
+  static final Logger LOGGER = Logger.getLogger(SSOPluginImpl.class.getName());
+
+  Filter filter;
+        /**
+       * Fetches the singleton instance of this plugin.
+       * @return the instance.
+       */
+      public static PluginImpl getInstance() {
+          Jenkins jenkins = Jenkins.getInstance();
+          if (jenkins != null) {
+              return jenkins.getPlugin(PluginImpl.class);
+          } else {
+              return null;
+          }
+      }
+
+      /**
+       * Starts the plugin. Loads previous configuration if such exists.
+       * @throws Exception if the Kerberos filter cannot be added to Jenkins.
+       */
+      @Override
+      public void start() throws Exception {
+          load();
+          try {
+              this.filter = new SSOFilter();
+                  PluginServletFilter.addFilter(filter);
+          } catch (ServletException e) {
+              LOGGER.log(Level.SEVERE, "Failed initialize plugin due to faulty config.", e);
+              removeFilter();
+          }
+      }
+
+      /**
+       * Stops this plugin and removes the filter from Jenkins.
+       * @throws Exception if removing the filter fails.
+       */
+      @Override
+      public void stop() throws Exception {
+          removeFilter();
+      }
+
+      /**
+       * Safe and complete removal of the filter from the system.
+       * @throws ServletException if
+       */
+      private void removeFilter() throws ServletException {
+          if (filter != null) {
+              PluginServletFilter.removeFilter(filter);
+              filter.destroy();
+              filter = null;
+          }
+      }
+}
+

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectory.groovy
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectory.groovy
@@ -11,7 +11,7 @@ import hudson.model.Hudson
 // global so that this bean can be retrieved as UserDetailsService
 if (realm.domain == null && realm.descriptor.canDoNativeAuth())
     // Windows path requires com4j, which is currently only supported on Win32
-    activeDirectory(ActiveDirectoryAuthenticationProvider)
+    activeDirectory(ActiveDirectoryAuthenticationProvider,realm)
 else
     activeDirectory(ActiveDirectoryUnixAuthenticationProvider,realm) {}
 

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
@@ -19,6 +19,59 @@
       <f:checkbox />
     </f:entry>
   </f:advanced>
+  <f:optionalBlock title="${%SSO Enabled}" field="ssoOptions" name="ssoOptions"  checked="${instance.ssoOptions!=null}">
+    <f:entry title="${%Portion of DN to use for the username}" field="userField" >
+      <f:textbox default="CN" value="${instance.ssoOptions.userField}"/>
+    </f:entry>
+
+    <f:entry title="${%Check SSO Username against Active Directory}" field="checkMode">    
+      <select name="checkMode">
+		<j:choose>
+            <j:when test="${instance.ssoOptions.checkMode eq 'no_change'}">
+                <option value="no_change" selected="selected">no change</option>
+            </j:when>
+            <j:otherwise>
+    	       <option value="no_change">no change</option>
+    	    </j:otherwise>
+    	</j:choose>      
+		<j:choose>
+            <j:when test="${instance.ssoOptions.checkMode eq 'lower'}">
+                <option value="lower" selected="selected">in lower case</option>
+            </j:when>
+            <j:otherwise>
+    	       <option value="lower">in lower case</option>
+    	    </j:otherwise>
+    	</j:choose>      
+		<j:choose>
+            <j:when test="${instance.ssoOptions.checkMode eq 'upper'}">
+                <option value="upper" selected="selected">in upper case</option>
+            </j:when>
+            <j:otherwise>
+    	       <option value="upper">in upper case</option>
+    	    </j:otherwise>
+    	</j:choose>      
+		<j:choose>
+            <j:when test="${instance.ssoOptions.checkMode eq 'no_check'}">
+                <option value="no_check" selected="selected">no check</option>
+            </j:when>
+            <j:otherwise>
+    	       <option value="no_check">no check</option>
+    	    </j:otherwise>
+    	</j:choose>      
+      </select>
+    </f:entry>
+    <f:entry align="left">
+    	<font color="red">${%IMPORTANT: Bind DN and password are mandatory when 'Check SSO Username against Active Directory' is enabled}</font>
+   	</f:entry>
+    <f:section title="${%Options when no SSO Username check against Active Directory is set}" align="left">
+      <f:entry title="${%Default group}" field="defaultGroup">
+        <f:textbox default="SSOUsers.no_check" value="${instance.ssoOptions.defaultGroup}" />
+      </f:entry>
+      <f:entry title="${%Jenkins username suffix}" field="jenkinsUsernameSuffix" >
+        <f:textbox default="@sso" value="${instance.ssoOptions.jenkinsUsernameSuffix}" />
+      </f:entry>
+    </f:section>
+  </f:optionalBlock>  
   <f:nested>
     <f:validateButton with="domain,server,site,bindName,bindPassword" title="${%Test}" method="validate"/>
   </f:nested>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-checkMode.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-checkMode.html
@@ -1,0 +1,32 @@
+<div>
+    <p>
+    Determines how Client certificate is checked against Active Directory. 
+    Except in "no check" mode, groups membership will be downloaded for the authenticated user from Active Directory. 
+    When a "check mode" is enabled against Active Directory, Bind DN and password fields are mandatory.
+
+    <p>
+    This option is available because, sometimes, the case of the "Portion of DN to use for the username" value can differ from the Active Directory username.
+
+    <dl>
+    <dt>no change
+    <dd>
+    The "Portion of DN to use for the username" value will be compared in a case sensitive mode against Active Directory. 
+
+
+    <dt>in lower case
+    <dd>
+    The "Portion of DN to use for the username" value will be converted in lower case before being compared against Active Directory. 
+
+    <dt>in upper case
+    <dd>
+    The "Portion of DN to use for the username" value will be converted in upper case before being compared against Active Directory. 
+
+    <dt>no check
+    <dd>
+    The "Portion of DN to use for the username" value will not be compared against Active Directory.
+    In this mode, groups membership will not be also downloaded from Active Directory. 
+
+    </dl>
+
+    <p>
+</div>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-defaultGroup.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-defaultGroup.html
@@ -1,0 +1,7 @@
+<div>
+	If "no check" mode is set as "Check SSO Username against Active Directory" value, users logged in with Client certificate will be member of this group by default.
+	This allows administrators to set specific rights to these users. 
+
+    <p>
+    Default value is SSOUsers.no_check
+</div>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-jenkinsUsernameSuffix.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-jenkinsUsernameSuffix.html
@@ -1,0 +1,6 @@
+<div>
+	If "no check" mode is set as "Check SSO Username against Active Directory" value, "Jenkins username suffix" is concatenated at the end of the "Portion of DN to use for the username" value to create a specific username for users logged in with Client certificate.
+
+    <p>
+    Default value is @sso but the best value should be the company SMTP email domain, for example @mycompany.com
+</div>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-ssoOptions.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-ssoOptions.html
@@ -1,0 +1,8 @@
+<div>
+	"SSO Enabled" activates Client certificate authentication in addition of the Active Directory username/password authentication. 
+    
+    <p>
+    This option assumes that you have a configured your servlet container to request a client certificate
+    and pass it on to Jenkins. Configuring clientAuth is covered in
+    <a href="http://tomcat.apache.org/tomcat-6.0-doc/ssl-howto.html#Edit_the_Tomcat_Configuration_File">Tomcat 6 documention</a>.
+</div>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-userField.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-userField.html
@@ -1,0 +1,12 @@
+<div>
+	X.500 "distinguished name" Entry containing the username to be used for the authentication and to be compared against Active Directory.
+	<p>
+	Default is CN
+	
+    <p>
+    For more information on X.500 format, please check:
+    <ul>
+    <li><a href="https://en.wikipedia.org/wiki/X.500">X.500</a></li>
+    <li><a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=64845">ISO/IEC 9594-1:2014 Information technology -- Open Systems Interconnection -- The Directory -- Part 1: Overview of concepts, models and services</a></li>
+    </ul>	 
+</div>


### PR DESCRIPTION
# Context
Today, there are two plugins: the active-directory-plugin & the certificate-authentication-plugin
Both are great plugins.

But in big infras, administrators need SSO/Client certificate authentication against an Active Directory server. This means, that some administrators manage their groups in active directory but needs their end users to be authenticated by using client certificates.

# Features
This pull request will enable a such request (see this Jira ticket:  [JENKINS-31575 Adding SSO/Client certificate authentication against Active Directory](https://issues.jenkins-ci.org/browse/JENKINS-31575)
The SSO can be:
* Disabled, in this case the active directory will be the old one/AD workflow working alone
* SSO Enabled without check against Active directory. authenticated users will have a prefix set in their username and will be put in a default group
* SSO enabled with some matching rules (lower/upper case forcing/no change). In this case Bind DN username/password will be mandatory, the client certificate CN will be checked against the Active Directory username and its groups membership will be downloaded

# Development details
* **Help files available for all new options**
* **Upgrade in the POM to org.jenkins-ci.plugins:plugin:1.554 is mandatory due to the use of the jenkins.security.SecurityListener class* in SSOFilter.java**

This is a really must have feature which will be largely used by DevOps and in large companies.

![Screenshot](https://issues.jenkins-ci.org/secure/attachment/31269/screenshot-1.png)

# Reference (links)
* [Original certificate authentication plugin](https://github.com/jenkinsci/certificate-authentication-plugin)
* [Discussion](https://groups.google.com/forum/#!topic/jenkinsci-dev/Cpmq4fD67po)
* [Jira ticket](https://issues.jenkins-ci.org/browse/JENKINS-31575)
