### PR TITLE
[FIXED JENKINS-33213] TimeLimitExceededException produces "Automatic" group lookup strategy not to work correctly

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -440,7 +440,6 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                     long start = System.nanoTime();
                     boolean found = false;
                     long duration = 0;
-
                     try {
                         found = chainGroupLookup(domainDN, userDN, context, groups);
                         duration = TimeUnit2.NANOSECONDS.toSeconds(System.nanoTime() - start);

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -437,7 +437,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                 switch (groupLookupStrategy) {
                 case AUTO:
                     // try the accurate one first, and if it's too slow fall back to recursive in the hope that it's faster
-                    long start = System.currentTimeMillis();
+                    long start = System.nanoTime();
                     boolean found = false;
                     long duration = 0;
 

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -444,7 +444,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                         found = chainGroupLookup(domainDN, userDN, context, groups);
                         duration = TimeUnit2.NANOSECONDS.toSeconds(System.nanoTime() - start);
                     } catch (TimeLimitExceededException e) {
-                        LOGGER.log(Level.WARNING, "LDAP response read time out. AD will fall back to recursive lookup", e);
+                        LOGGER.log(Level.WARNING, "The LDAP request did not terminate within the specified time limit. AD will fall back to recursive lookup", e);
                     } catch (NamingException e) {
                         if (e.getMessage().contains("LDAP response read timed out")) {
                             LOGGER.log(Level.WARNING, "LDAP response read time out. AD will fall back to recursive lookup", e);


### PR DESCRIPTION
The following stacktrace seems to produce active directory plugin not to fallback into recursive strategy.

```
Feb 23, 2016 9:31:54 AM hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider retrieveUser
WARNING: Failed to retrieve user information for xxxx
javax.naming.TimeLimitExceededException: [LDAP: error code 3 - Timelimit Exceeded]; remaining name 'DC=xxx,DC=xx,DC=company,DC=com'
	at com.sun.jndi.ldap.LdapCtx.mapErrorCode(LdapCtx.java:3143)
	at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:3033)
	at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:2840)
	at com.sun.jndi.ldap.LdapNamingEnumeration.getNextBatch(LdapNamingEnumeration.java:147)
	at com.sun.jndi.ldap.LdapNamingEnumeration.hasMoreImpl(LdapNamingEnumeration.java:216)
	at com.sun.jndi.ldap.LdapNamingEnumeration.hasMore(LdapNamingEnumeration.java:189)
	at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.parseMembers(ActiveDirectoryUnixAuthenticationProvider.java:533)
	at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.chainGroupLookup(ActiveDirectoryUnixAuthenticationProvider.java:478)
	at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.resolveGroups(ActiveDirectoryUnixAuthenticationProvider.java:438)
	at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.retrieveUser(ActiveDirectoryUnixAuthenticationProvider.java:318)
	at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.retrieveUser(ActiveDirectoryUnixAuthenticationProvider.java:219)
	at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.retrieveUser(ActiveDirectoryUnixAuthenticationProvider.java:163)
	at hudson.plugins.active_directory.ActiveDirectorySecurityRealm.authenticate(ActiveDirectorySecurityRealm.java:666)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at com.cloudbees.opscenter.server.sso.RemoteSecurityRealmImpl.authenticate(RemoteSecurityRealmImpl.java:200)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:608)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:583)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:542)
	at hudson.remoting.UserRequest.perform(UserRequest.java:120)
	at hudson.remoting.UserRequest.perform(UserRequest.java:48)
	at hudson.remoting.Request$2.run(Request.java:326)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at org.jenkinsci.remoting.CallableDecorator.call(CallableDecorator.java:18)
	at hudson.remoting.CallableDecoratorList$1.call(CallableDecoratorList.java:21)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:744)
```

Related to #20 

@reviewbybees CC @jtnord 

