### PR TITLE
[FIXED JENKINS-34143] Test Active Directory connection button reports success if the search operation doesn't have any result

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -389,7 +389,10 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                             DirContext context = bind(bindName, Secret.toString(password), servers);
                             try {
                                 // actually do a search to make sure the credential is valid
-                                new LDAPSearchBuilder(context, toDC(name)).searchOne("(objectClass=user)");
+                                Attributes userAttributes = new LDAPSearchBuilder(context, toDC(name)).searchOne("(objectClass=user)");
+                                if (userAttributes == null) {
+                                    return FormValidation.error(Messages.ActiveDirectorySecurityRealm_NoUsers());
+                                }
                             } finally {
                                 context.close();
                             }

--- a/src/main/resources/hudson/plugins/active_directory/Messages.properties
+++ b/src/main/resources/hudson/plugins/active_directory/Messages.properties
@@ -3,3 +3,5 @@ DisplayName=Active Directory
 GroupLookupStrategy.Auto=Automatic
 GroupLookupStrategy.Recursive=Recursive group queries
 GroupLookupStrategy.ChainMatch=LDAP_MATCHING_RULE_IN_CHAIN
+
+ActiveDirectorySecurityRealm.NoUsers=The bind with the managerDn was successful but AD was not able to find any user.


### PR DESCRIPTION
When testing the AD connection details you need to actually do a search to make sure the credential is valid.
https://github.com/jenkinsci/active-directory-plugin/blob/master/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java#L392
If in this search there are not elements, we are returning null.
https://github.com/jenkinsci/active-directory-plugin/blob/master/src/main/java/hudson/plugins/active_directory/LDAPSearchBuilder.java#L98
And in this case we are saying that everything is success.
https://github.com/jenkinsci/active-directory-plugin/blob/master/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java#L425
it might happen that under AD replication farm one of the AD instances is broken not returning any user in the search. In this case, we should expose the issue on the GUI.

https://issues.jenkins-ci.org/browse/JENKINS-34143

@reviewbybees @escoem @andresrc @jtnord 