### PR TITLE
[FIXED JENKINS-34444] Test button is reporting managerDN binding is successful but was not able to find any user on the tree

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -439,7 +439,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                             DirContext context = bind(bindName, Secret.toString(password), servers);
                             try {
                                 // actually do a search to make sure the credential is valid
-                                Attributes userAttributes = new LDAPSearchBuilder(context, toDC(name)).searchOne("(objectClass=user)");
+                                Attributes userAttributes = new LDAPSearchBuilder(context, toDC(name)).subTreeScope().searchOne("(objectClass=user)");
                                 if (userAttributes == null) {
                                     return FormValidation.error(Messages.ActiveDirectorySecurityRealm_NoUsers());
                                 }


### PR DESCRIPTION
In case in the root tree there are only OU and any USER, then the ad test button will report this. It is better to use a subtree scope so we actually look inside OUs.

https://issues.jenkins-ci.org/browse/JENKINS-34444

@reviewbybees CC @jtnord 