### PR TITLE
[FIXED JENKINS-34968] Domain in login is not taken into account

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -451,17 +451,18 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
      * Returns the full user principal name of the form "joe@europe.contoso.com".
      * 
      * If people type in 'foo@bar' or 'bar\foo' or just 'foo', it should be treated as
-     * 'foo@bar' (where 'bar' represents the given domain name)
+     * 'foo@bar.acme.org' (where 'acme.org' part comes from the given domain name in the AD configuration page)
      */
     private String getPrincipalName(String username, String domainName) {
         String principalName;
         int slash = username.indexOf('\\');
         if (slash>0) {
-            principalName = username.substring(slash+1)+'@'+domainName;
-        } else if (username.contains("@"))
+            principalName = username.substring(slash+1) + '@' + username.substring(0, slash) + '.' + domainName;
+        } else if (username.contains("@")) {
             principalName = username;
-        else
-            principalName = username+'@'+domainName;
+        } else {
+            principalName = username + '@' + domainName;
+        }
         return principalName;
     }
 


### PR DESCRIPTION
If we write subdomain in the login, then this subdomain is not taken into account.

This is related to changes by this commit: https://github.com/jenkinsci/active-directory-plugin/commit/7c04f787b84cb7cd376ebb25d0b15ec649264c07

This is incorrect:
If people type in 'foo@bar' or 'bar\foo' or just 'foo', it should be treated as 'foo@bar' (where 'bar' represents the given domain name)

'bar' is represent a domain name which is set in the configuration, not in the login.

For example we set our Domain Name to 'bar.com'. Then we write login 'subbar\foo'. We expect to transform this to 'foo@subbar.bar.com'. But instead a 'foo@bar.com' is used.

https://issues.jenkins-ci.org/browse/JENKINS-34968

@reviewbybees @jtnord