### PR TITLE
[JENKINS-36248] Provide an ultimate speed option.

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/GroupLookupStrategy.java
+++ b/src/main/java/hudson/plugins/active_directory/GroupLookupStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2008-2014, Kohsuke Kawaguchi, CloudBees, Inc., and contributors
+ * Copyright (c) 2008-2016, Kohsuke Kawaguchi, CloudBees, Inc., and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,9 +38,10 @@ import org.jvnet.localizer.Localizable;
  * @author Kohsuke Kawaguchi
  */
 /*hidden*/ enum GroupLookupStrategy {
-    AUTO     (Messages._GroupLookupStrategy_Auto()),
-    RECURSIVE(Messages._GroupLookupStrategy_Recursive()),
-    CHAIN    (Messages._GroupLookupStrategy_ChainMatch()),
+    AUTO           (Messages._GroupLookupStrategy_Auto()),
+    RECURSIVE      (Messages._GroupLookupStrategy_Recursive()),
+    CHAIN          (Messages._GroupLookupStrategy_ChainMatch()),
+    TOKENGROUPS    (Messages._GroupLookupStrategy_TokenGroups())
     ;
 
     public final Localizable msg;

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-groupLookupStrategy.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-groupLookupStrategy.html
@@ -36,6 +36,17 @@
     The general consensus in the developer community appears to be that <a href="http://www.networksteve.com/forum/topic.php/?TopicId=43899">this is the way to go</a>,
     but several Jenkins users have reported that <a href="https://issues.jenkins-ci.org/browse/JENKINS-22830">this approach makes lookup intolerably slow</a>.
 
+    <dt>Token-Groups user attribute
+    <dd>
+    Use only the <a href="https://msdn.microsoft.com/en-us/library/ms680275(v=vs.85).aspx">Token-Groups</a> attribute.
+    This attribute will contain all the <a href="https://technet.microsoft.com/en-gb/library/cc781446(v=ws.10).aspx">security groups</a> that a user is a member of, 
+    including all security groups via recursion of other security groups.
+    If the user is a member of any <a href="https://technet.microsoft.com/en-gb/library/cc781446(v=ws.10).aspx">distribution groups</a>, or security groups via membership of a 
+    distribution group then these will not be included in the returned groups.
+    However if users are members of large number of distribution groups and your security setup does not require the use of distribution groups 
+    then this will provide the ultimate performance.
+
+
     </dl>
 
     <p>

--- a/src/main/resources/hudson/plugins/active_directory/Messages.properties
+++ b/src/main/resources/hudson/plugins/active_directory/Messages.properties
@@ -3,5 +3,6 @@ DisplayName=Active Directory
 GroupLookupStrategy.Auto=Automatic
 GroupLookupStrategy.Recursive=Recursive group queries
 GroupLookupStrategy.ChainMatch=LDAP_MATCHING_RULE_IN_CHAIN
+GroupLookupStrategy.TokenGroups=Token-Groups user attribute
 
 ActiveDirectorySecurityRealm.NoUsers=The bind with the managerDn was successful but AD was not able to find any user.


### PR DESCRIPTION
If the AD setup only requires Security Groups then we already have these
from the token-groups attribute, so searching memberOf will just make
login take longer.

The exception to this is if you have users are members of a security group
via way of a intermediate distribution group, but for these cases you can
still choose one of the other 2 methods.

@reviewbybees 
[JENKINS-36248](https://issues.jenkins-ci.org/browse/JENKINS-36248)