### PR TITLE
[JENKINS-36212] Not serialize userCache, neither groupCache

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/CacheConfiguration.java
+++ b/src/main/java/hudson/plugins/active_directory/CacheConfiguration.java
@@ -17,12 +17,12 @@ public class CacheConfiguration<K,V,E extends Exception> {
     /**
      * The {@link UserDetails} cache.
      */
-    private final Cache<String, UserDetails> userCache;
+    private transient final Cache<String, UserDetails> userCache;
 
     /**
      * The {@link ActiveDirectoryGroupDetails} cache.
      */
-    private final Cache<String, ActiveDirectoryGroupDetails> groupCache;
+    private transient final Cache<String, ActiveDirectoryGroupDetails> groupCache;
 
     /**
      * CacheConfiguration DataBoundConstructor


### PR DESCRIPTION
When you configure the AD plugin (1.47) with a cache the main jenkins config contains the internals of the cache implementation and not the specific cache configuration.

```
  <securityRealm class="hudson.plugins.active_directory.ActiveDirectorySecurityRealm" plugin="active-directory@1.47">
    <domain>internal.local</domain>
    <bindName>binduser</bindName>
    <bindPassword>somevalue</bindPassword>
    <server>someServer:3268</server>
    <groupLookupStrategy>RECURSIVE</groupLookupStrategy>
    <removeIrrelevantGroups>false</removeIrrelevantGroups>
    <cache>
      <size>256</size>
      <ttl>30</ttl>
      <userCache class="com.google.common.cache.LocalCache$LocalManualCache" resolves-to="com.google.common.cache.LocalCache$ManualSerializationProxy">
        <keyStrength>STRONG</keyStrength>
        <valueStrength>STRONG</valueStrength>
        <keyEquivalence class="com.google.common.base.Equivalences$Equals"/>
        <valueEquivalence class="com.google.common.base.Equivalences$Equals" reference="../keyEquivalence"/>
        <expireAfterWriteNanos>30000000000</expireAfterWriteNanos>
        <expireAfterAccessNanos>0</expireAfterAccessNanos>
        <maxWeight>256</maxWeight>
        <weigher class="com.google.common.cache.CacheBuilder$OneWeigher">INSTANCE</weigher>
        <concurrencyLevel>4</concurrencyLevel>
        <removalListener class="com.google.common.cache.CacheBuilder$NullListener">INSTANCE</removalListener>
      </userCache>
      <groupCache class="com.google.common.cache.LocalCache$LocalManualCache" resolves-to="com.google.common.cache.LocalCache$ManualSerializationProxy">
        <keyStrength>STRONG</keyStrength>
        <valueStrength>STRONG</valueStrength>
        <keyEquivalence class="com.google.common.base.Equivalences$Equals" reference="../../userCache/keyEquivalence"/>
        <valueEquivalence class="com.google.common.base.Equivalences$Equals" reference="../../userCache/keyEquivalence"/>
        <expireAfterWriteNanos>30000000000</expireAfterWriteNanos>
        <expireAfterAccessNanos>0</expireAfterAccessNanos>
        <maxWeight>256</maxWeight>
        <weigher class="com.google.common.cache.CacheBuilder$OneWeigher">INSTANCE</weigher>
        <concurrencyLevel>4</concurrencyLevel>
        <removalListener class="com.google.common.cache.CacheBuilder$NullListener">INSTANCE</removalListener>
      </groupCache>
    </cache>
  </securityRealm>
```


https://issues.jenkins-ci.org/browse/JENKINS-36212

@reviewbybees CC @jtnord @andresrc 

