### PR TITLE
JENKINS-38444 Only re-try when domainControllers are specified

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -338,7 +338,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                             // if we've used the credential specifically for the bind, we
                             // need to verify the provided password to do authentication
                             LOGGER.log(Level.FINE, "Attempting to validate password for DN={0}", dn);
-                            DirContext test = descriptor.bind(dnFormatted, password, ldapServers, props);
+                            DirContext test = descriptor.bind(dnFormatted, password, server !=  null && !server.isEmpty(), ldapServers, props);
                             // Binding alone is not enough to test the credential. Need to actually perform some query operation.
                             // but if the authentication fails this throws an exception
                             try {


### PR DESCRIPTION
All the details are here:
https://github.com/jenkinsci/active-directory-plugin/pull/41

Basically, by doing this you might be locking an user account with a bad password specially in case where the ldapServers are discovered automatically by the plugin, as it will be trying to authenticate through all the tree getting BadCredentialsException and then you might be locking your account per hitting the max of retries.

I know that perhaps the right multiDomain implementation is to modify the UI to be able to link domains and corresponded domainControllers to make it easy later on the back end, but this is something I would like to do later on.
@reviewbybees @jtnord 

