### PR TITLE
[FIXED JENKINS-40599] Not throw any Exception in case there is not any domain configured in the descriptor

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -126,9 +126,6 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
     private final static String LDAP_READ_TIMEOUT = "com.sun.jndi.ldap.read.timeout";
 
     public ActiveDirectoryUnixAuthenticationProvider(ActiveDirectorySecurityRealm realm) {
-        if (realm.domains==null) {
-            throw new IllegalArgumentException("An Active Directory domain name is required but it is not set");
-        }
         this.site = realm.site;
         this.domains = realm.domains;
         this.groupLookupStrategy = realm.getGroupLookupStrategy();


### PR DESCRIPTION
Jenkins cannot be initialized in case the descriptor of the AD plugin is saved without any domain

```
SEVERE: Failed to initialize Jenkins
hudson.util.HudsonFailedToLoad: org.jvnet.hudson.reactor.ReactorException: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'activeDirectory': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Could not instantiate bean class [hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider]: Constructor threw exception; nested exception is java.lang.IllegalArgumentException: An Active Directory domain name is required but it is not set
	at hudson.WebAppMain$3.run(WebAppMain.java:234)
Caused by: org.jvnet.hudson.reactor.ReactorException: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'activeDirectory': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Could not instantiate bean class [hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider]: Constructor threw exception; nested exception is java.lang.IllegalArgumentException: An Active Directory domain name is required but it is not set
	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:269)
	at jenkins.InitReactorRunner.run(InitReactorRunner.java:44)
	at jenkins.model.Jenkins.executeReactor(Jenkins.java:910)
	at jenkins.model.Jenkins.<init>(Jenkins.java:809)
	at hudson.model.Hudson.<init>(Hudson.java:82)
	at hudson.model.Hudson.<init>(Hudson.java:78)
	at hudson.WebAppMain$3.run(WebAppMain.java:222)
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'activeDirectory': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Could not instantiate bean class [hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider]: Constructor threw exception; nested exception is java.lang.IllegalArgumentException: An Active Directory domain name is required but it is not set
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:254)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:925)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:835)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:440)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory$1.run(AbstractAutowireCapableBeanFactory.java:409)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:380)
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:264)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:261)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:185)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:164)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:429)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:728)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:380)
	at hudson.util.spring.DefaultRuntimeSpringConfiguration.getApplicationContext(DefaultRuntimeSpringConfiguration.java:94)
	at hudson.util.spring.BeanBuilder.createApplicationContext(BeanBuilder.java:388)
	at hudson.plugins.active_directory.ActiveDirectorySecurityRealm.createSecurityComponents(ActiveDirectorySecurityRealm.java:275)
	at hudson.security.SecurityRealm.getSecurityComponents(SecurityRealm.java:420)
	at hudson.security.HudsonFilter.reset(HudsonFilter.java:134)
	at jenkins.model.Jenkins.setSecurityRealm(Jenkins.java:2052)
	at jenkins.model.Jenkins$20.run(Jenkins.java:2650)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:899)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.springframework.beans.BeanInstantiationException: Could not instantiate bean class [hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider]: Constructor threw exception; nested exception is java.lang.IllegalArgumentException: An Active Directory domain name is required but it is not set
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:115)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:87)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:248)
	... 29 more
Caused by: java.lang.IllegalArgumentException: An Active Directory domain name is required but it is not set
	at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.<init>(ActiveDirectoryUnixAuthenticationProvider.java:130)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:100)
	... 31 more
```

This due this line of code:
https://github.com/jenkinsci/active-directory-plugin/blob/active-directory-2.0/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java#L132

https://issues.jenkins-ci.org/browse/JENKINS-40599