### PR TITLE
[FIXED JENKINS-36041 JENKINS-25269] Enable com.sun.jndi.ldap.connect.timeout

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -506,7 +506,10 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
             }
 
             newProps.put("java.naming.ldap.attributes.binary","tokenGroups objectSid");
-            newProps.put("java.naming.ldap.factory.socket",TrustAllSocketFactory.class.getName());
+
+            if (FORCE_LDAPS) {
+                newProps.put("java.naming.ldap.factory.socket", TrustAllSocketFactory.class.getName());
+            }
             newProps.putAll(props);
             NamingException namingException = null;
 
@@ -584,10 +587,8 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                         LOGGER.fine("Connection upgraded to TLS");
                     } catch (NamingException e) {
                         LOGGER.log(Level.FINE, "Failed to start TLS. Authentication will be done via plain-text LDAP", e);
-                        context.removeFromEnvironment("java.naming.ldap.factory.socket");
                     } catch (IOException e) {
                         LOGGER.log(Level.FINE, "Failed to start TLS. Authentication will be done via plain-text LDAP", e);
-                        context.removeFromEnvironment("java.naming.ldap.factory.socket");
                     }
                 }
 

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -187,8 +187,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
         );
 
         Map<String, String> extraEnvVarsMap = ActiveDirectorySecurityRealm.EnvironmentProperty.toMap(realm.environmentProperties);
-        // TODO In JDK 8u65 I am facing JDK-8139721, JDK-8139942 which makes the plugin to break. Uncomment line once it is fixed.
-        //props.put(LDAP_CONNECT_TIMEOUT, System.getProperty(LDAP_CONNECT_TIMEOUT, DEFAULT_LDAP_CONNECTION_TIMEOUT));
+        props.put(LDAP_CONNECT_TIMEOUT, System.getProperty(LDAP_CONNECT_TIMEOUT, DEFAULT_LDAP_CONNECTION_TIMEOUT));
         props.put(LDAP_READ_TIMEOUT, System.getProperty(LDAP_READ_TIMEOUT, DEFAULT_LDAP_READ_TIMEOUT));
         // put all the user defined properties into our context environment replacing any mappings that already exist.
         props.putAll(extraEnvVarsMap);


### PR DESCRIPTION
Enable `com.sun.jndi.ldap.connect.timeout` - the reason why it was not enabled before is that I thought it was failing for a JDK issue, but the real issue was that the plugin was injecting `TrustAllSocketFactory` even under plain communication - this was also making startTLS not to work.