### PR TITLE
[FIXED JENKINS-42462] Use subTreeScope when double checking the validity of the user

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -372,7 +372,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                             // Binding alone is not enough to test the credential. Need to actually perform some query operation.
                             // but if the authentication fails this throws an exception
                             try {
-                                new LDAPSearchBuilder(test, domainDN).searchOne("(& (userPrincipalName={0})(objectCategory=user))", userPrincipalName);
+                                new LDAPSearchBuilder(test, domainDN).subTreeScope().searchOne("(& (userPrincipalName={0})(objectCategory=user))", userPrincipalName);
                             } finally {
                                 closeQuietly(test);
                             }


### PR DESCRIPTION
This line of code

https://github.com/jenkinsci/active-directory-plugin/blob/active-directory-2.0/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java#L339

should be at very least

```
new LDAPSearchBuilder(test, domainDN).subTreeScope().searchOne("(& (userPrincipalName={0})(objectCategory=user))", userPrincipalName);
```

with the subTreeScope to be able to find the user!

https://issues.jenkins-ci.org/browse/JENKINS-42462