### PR TITLE
[FIXED JENKINS-42462] Not have subTreeScope on the latest lookup

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -372,7 +372,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                             // Binding alone is not enough to test the credential. Need to actually perform some query operation.
                             // but if the authentication fails this throws an exception
                             try {
-                                new LDAPSearchBuilder(test, domainDN).subTreeScope().searchOne("(& (userPrincipalName={0})(objectCategory=user))", userPrincipalName);
+                                new LDAPSearchBuilder(test, domainDN).searchOne("(& (userPrincipalName={0})(objectCategory=user))", userPrincipalName);
                             } finally {
                                 closeQuietly(test);
                             }


### PR DESCRIPTION
I thought that `JENKINS-42462` was really an issue, but thinking more about it I think that on the last step of retrieving an user where you do

```
// Binding alone is not enough to test the credential. Need to actually perform some query operation.
                            // but if the authentication fails this throws an exception
                            try {
                                new LDAPSearchBuilder(test, domainDN).searchOne("(& (userPrincipalName={0})(objectCategory=user))", userPrincipalName);
                            } finally {
                                closeQuietly(test);
                            }
```

subTreeScope() should be there as the important thing is not to even find the user, but just ensure that when launching the query we are not getting any exception.

Adding subTreeScope() could also have an important performance impact, so I prefer to be conservative.