### PR TITLE
[JENKINS-43091] Guice failing on terminating ActiveDirectorySecurityRealm.shutDownthreadPoolExecutors

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -432,7 +432,6 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     }
 
     @Restricted(DoNotUse.class)
-    @Terminator
     public void shutDownthreadPoolExecutors() {
         threadPoolExecutor.shutdown();
     }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-43091