### PR TITLE
[FIXED JENKINS-45009] If getRecordFromDomain returns null report the problem

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
@@ -280,7 +280,7 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
 
                 // There should be only one domain as the fake domain only contains one
                 for (ActiveDirectoryDomain activeDirectoryDomain : activeDirectoryDomains) {
-                    if (activeDirectoryDomain.getRecordFromDomain() != null) {
+                    if (activeDirectoryDomain.getRecordFromDomain() == null) {
                         return FormValidation.error(name + " doesn't look like a valid domain name");
                     }
                 }


### PR DESCRIPTION
After updating to the active directory plugin version 2.5 the validity domain test button is incorrectly reporting that the domain is not valid. This is a regression from the previous version 2.4.

The bug was introduced in the commit https://github.com/jenkinsci/active-directory-plugin/commit/4e46466#diff-89b7b6ee37e6be852370249c03e7ca8cR283.  It's checking for not null and reporting an error when it should do the opposite.

https://issues.jenkins-ci.org/browse/JENKINS-45009