### PR TITLE
[FIXED JENKINS-45816] Fix ActiveDirectorySecurityRealm constructor ignoring passed in TlsConfiguration

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -247,7 +247,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
 
     public ActiveDirectorySecurityRealm(String domain, List<ActiveDirectoryDomain> domains, String site, String bindName,
                                         String bindPassword, String server, GroupLookupStrategy groupLookupStrategy, boolean removeIrrelevantGroups, Boolean customDomain, CacheConfiguration cache, Boolean startTls, TlsConfiguration tlsConfiguration) {
-        this(domain, domains, site, bindName, bindPassword, server, groupLookupStrategy, removeIrrelevantGroups, customDomain, cache, startTls, TlsConfiguration.TRUST_ALL_CERTIFICATES, null);
+        this(domain, domains, site, bindName, bindPassword, server, groupLookupStrategy, removeIrrelevantGroups, customDomain, cache, startTls, tlsConfiguration, null);
     }
 
     @DataBoundConstructor


### PR DESCRIPTION
This fixes a bug where the ActiveDirectorySecurityRealm constructor always selects `TlsConfiguration.TRUST_ALL_CERTIFICATES`, regardless of what the caller passes in. 

ActiveDirectorySecurityRealm now honors passed in TlsConfiguration making it possible to programmatically select "JDK TrustStore" when creating an ActiveDirectorySecurityRealm.