### PR TITLE
[FIXED JENKINS-45576] AD recognizes groups by CN and sAMAccount when authorities only works with CN

### DIFF
--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -126,7 +126,6 @@ public class TheFlintstonesTest {
     @Issue("JENKINS-45576")
     @Test
     public void loadGroupFromAlias() throws Exception {
-
         // required to monitor the log messages, removing this line the test will fail
         List<String> logMessages = captureLogMessages(20);
 
@@ -144,7 +143,6 @@ public class TheFlintstonesTest {
     }
 
     private List<String> captureLogMessages(int size) {
-
         final List<String> logMessages = new ArrayList<String>(size);
         Logger logger = Logger.getLogger("");
         logger.setLevel(Level.ALL);

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -
 
 #
 # Custom script to add users, groups and add users to groups
@@ -6,12 +6,27 @@
 
 # add groups
 samba-tool group add The-Flintstones
+samba-tool group add "The Rubbles"
 
 # add users
 samba-tool user add Fred ia4uV1EeKait
 samba-tool user add Wilma ia4uV1EeKait
-
+samba-tool user add Barney ia4uV1EeKait
+samba-tool user add Betty ia4uV1EeKait
 
 # add users to groups
 samba-tool group addmembers The-Flintstones Fred
 samba-tool group addmembers The-Flintstones Wilma
+samba-tool group addmembers "The Rubbles" Barney
+
+# add alias for the "The Rubbles"
+{ cat > file.ldif <<-EOF
+dn: CN=The Rubbles,cn=Users,dc=samdom,dc=example,dc=com
+changetype: modify
+replace: sAMAccountName
+sAMAccountName: Rubbles
+EOF
+} && ldapmodify -a -h 127.0.0.1 -p 389 -D "cn=Administrator,cn=Users,dc=samdom,dc=example,dc=com" -w "ia4uV1EeKait" -f file.ldif
+
+# add Betty to Rubbles alias
+samba-tool group addmembers Rubbles Betty

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/bin/bash
 
 #
 # Custom script to add users, groups and add users to groups


### PR DESCRIPTION
Allowing search groups by `sAMAccount` will continue causing issues because Jenkins is considering the same AD group as two different (the one resolved by `cn` and the other by `sAMAccount`).

This PR tries to workaround the problem, not allowing search a group by `sAMAccount` and prints a log message highlighting it.

I've also added a couple of tests