### PR TITLE
[FIXED JENKINS-47133] Anonymous binding doesn't retrieve the user groups

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
@@ -271,6 +271,10 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
                     return FormValidation.error("No domain was set");
                 }
 
+                if (StringUtils.isBlank(bindName)) {
+                    return FormValidation.warningWithMarkup("Leaving blank <b>`Bind DN`</b> means that any operation performed will use anonymous binding. Keep in mind that this is not recommended as some servers <a href=\"https://support.microsoft.com/en-us/help/326690/anonymous-ldap-operations-to-active-directory-are-disabled-on-windows\">do not allow it by default.</a>");
+                }
+
                 Secret password = Secret.fromString(bindPassword);
                 if (bindName!=null && password==null)
                     return FormValidation.error("Bind DN is specified but not the password");

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -436,6 +436,13 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                             // see JENKINS-12619. On my AD the error code is DSID-0C0906DC
                             throw new UserMayOrMayNotExistException("Unable to retrieve the user information without bind DN/password configured");
                         }
+                        if (anonymousBind && e.getMessage().contains("Operation unavailable without authentication") && e.getMessage().contains("00002020")) {
+                            // sometimes (or always?) anonymous bind itself will succeed but the actual query will fail.
+                            // see JENKINS-47133
+                            String msg = String.format("Server doesn't allow to retrieve the information for user `%s` without bind DN/password configured", username);
+                            LOGGER.log(Level.WARNING, msg);
+                            throw new UserMayOrMayNotExistException(msg);
+                        }
 
                         LOGGER.log(Level.WARNING, String.format("Failed to retrieve user information for %s", username), e);
                         throw new BadCredentialsException("Failed to retrieve user information for " + username, e);


### PR DESCRIPTION
This is not an issue on the plugin side but in the server. Added a warning message in case you leave blank the "Bind DN" field