### PR TITLE
Update Plugin POM to 3.3, use 1.625.3 as a minimum core requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.7</version>
+    <version>3.3</version>
   </parent>
 
   <artifactId>active-directory</artifactId>
@@ -33,9 +33,8 @@
   </developers>
 
   <properties>
-    <jenkins.version>1.554.1</jenkins.version>
-    <java.level>6</java.level>
-    <java.level.test>7</java.level.test>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
     <powermock.version>1.6.1</powermock.version>
   </properties>
 
@@ -44,11 +43,23 @@
       <groupId>org.jvnet.com4j.typelibs</groupId>
       <artifactId>ado20</artifactId>
       <version>1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jvnet.com4j</groupId>
+          <artifactId>com4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jvnet.com4j.typelibs</groupId>
       <artifactId>active-directory</artifactId>
       <version>1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jvnet.com4j</groupId>
+          <artifactId>com4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jvnet.com4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.3</version>
+    <version>3.4</version>
   </parent>
 
   <artifactId>active-directory</artifactId>

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryMailAddressResolverImpl.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryMailAddressResolverImpl.java
@@ -24,10 +24,10 @@
 package hudson.plugins.active_directory;
 
 import hudson.Extension;
-import hudson.model.Hudson;
 import hudson.model.User;
 import hudson.security.SecurityRealm;
 import hudson.tasks.MailAddressResolver;
+import jenkins.model.Jenkins;
 import org.acegisecurity.AcegiSecurityException;
 import org.springframework.dao.DataAccessException;
 
@@ -46,7 +46,7 @@ import static java.util.logging.Level.*;
 public class ActiveDirectoryMailAddressResolverImpl extends
 		MailAddressResolver {
 	public String findMailAddressFor(User u) {
-		SecurityRealm realm = Hudson.getInstance().getSecurityRealm();
+		SecurityRealm realm = Jenkins.getActiveInstance().getSecurityRealm();
 		if(!(realm instanceof ActiveDirectorySecurityRealm)){
 			return null;
 		}   

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -34,7 +34,6 @@ import hudson.init.Terminator;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.GroupDetails;
@@ -350,7 +349,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
             }
         };
         rms.setUserDetailsService(uds);
-        rms.setKey(Hudson.getInstance().getSecretKey());
+        rms.setKey(Jenkins.getActiveInstance().getSecretKey());
         rms.setParameter("remember_me"); // this is the form field name in login.jelly
 
         return new SecurityComponents( findBean(AuthenticationManager.class, context), uds, rms);
@@ -423,7 +422,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
      */
     public void doAuthTest(StaplerRequest req, StaplerResponse rsp, @QueryParameter String username, @QueryParameter String password) throws IOException, ServletException {
         // require the administrator permission since this is full of debug info.
-        Hudson.getInstance().checkPermission(Hudson.ADMINISTER);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
 
         StringWriter out = new StringWriter();
         PrintWriter pw = new PrintWriter(out);
@@ -661,7 +660,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                 LdapContext context = (LdapContext)LdapCtxFactory.getLdapCtxInstance(ldapUrl, props);
 
                 boolean isStartTls = true;
-                SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+                SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
                 if (securityRealm instanceof ActiveDirectorySecurityRealm) {
                     ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) securityRealm;
                      isStartTls= activeDirectorySecurityRealm.isStartTls();
@@ -929,7 +928,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     public static final class TlsConfigurationAdministrativeMonitor extends AdministrativeMonitor {
 
         public boolean isActivated() {
-                SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+                SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
                 if (securityRealm instanceof ActiveDirectorySecurityRealm) {
                     ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) securityRealm;
                     if (activeDirectorySecurityRealm.tlsConfiguration == null) {

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryStatus.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryStatus.java
@@ -79,7 +79,7 @@ public class ActiveDirectoryStatus extends ManagementLink {
      */
     @Restricted(NoExternalUse.class)
     public static List<ActiveDirectoryDomain> getDomains() {
-    SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+    SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
     if (securityRealm instanceof ActiveDirectorySecurityRealm) {
         ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) securityRealm;
         return activeDirectorySecurityRealm.getDomains();
@@ -103,7 +103,7 @@ public class ActiveDirectoryStatus extends ManagementLink {
                         return;
                     }
                     if (domainItem.getName().equals(domain)) {
-                        SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+                        SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
                         if (securityRealm instanceof ActiveDirectorySecurityRealm) {
                             ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) securityRealm;
                             List<SocketInfo> servers = activeDirectorySecurityRealm.getDescriptor().obtainLDAPServer(domainItem);
@@ -184,7 +184,7 @@ public class ActiveDirectoryStatus extends ManagementLink {
         private long computeLoginExecutionTime() {
             String username = Jenkins.getAuthentication().getName();
             long t0 = System.currentTimeMillis();
-            UserDetails userDetails = Jenkins.getInstance().getSecurityRealm().loadUserByUsername(username);
+            UserDetails userDetails = Jenkins.getActiveInstance().getSecurityRealm().loadUserByUsername(username);
             long t1 = System.currentTimeMillis();
             return  (userDetails!=null) ? (t1 - t0) : -1;
         }

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUserDetail.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUserDetail.java
@@ -123,12 +123,13 @@ public class ActiveDirectoryUserDetail extends User {
     @Override 
     @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="https://github.com/jenkinsci/jenkins/pull/2094")
     protected void setAuthorities(GrantedAuthority[] authorities) {
-        SecurityRealm realm = Jenkins.getInstance().getSecurityRealm();
+        final Jenkins jenkins = Jenkins.getActiveInstance();
+	    SecurityRealm realm = jenkins.getSecurityRealm();
         if ((realm instanceof ActiveDirectorySecurityRealm)) {
             ActiveDirectorySecurityRealm activeDirectoryRealm = (ActiveDirectorySecurityRealm)realm;
             if (activeDirectoryRealm.removeIrrelevantGroups) {
                 Set<String> referencedGroups = new HashSet<String>();
-                for (String group : Jenkins.getInstance().getAuthorizationStrategy().getGroups()) {
+                for (String group : jenkins.getAuthorizationStrategy().getGroups()) {
                     referencedGroups.add(group.toLowerCase());
                 }
                 // We remove irrelevant groups only if the active AuthorizationStrategy has any referenced groups:


### PR DESCRIPTION
A part of https://github.com/jenkinsci/configuration-as-code-plugin/issues/47

Some components use obsolete com4j, and it blows up the dependency check. I also bupbed the core requirement to 1.625.3, so now we do not need to bother about test/build environment differences. http://stats.jenkins.io/pluginversions/active-directory.html says that more than 95% of users run on newer core versions.

@reviewbybees 

