### PR TITLE
[FIXED JENKINS-52045] Tlsconfiguration in native auth & Advanced section in not native auth running on Windows box

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -931,7 +931,8 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                 SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
                 if (securityRealm instanceof ActiveDirectorySecurityRealm) {
                     ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) securityRealm;
-                    if (activeDirectorySecurityRealm.tlsConfiguration == null) {
+                    // AdministrativeMonitor only available if there is not any tlsConfiguration persistent on disk and not doing native authentication
+                    if (activeDirectorySecurityRealm.tlsConfiguration == null && !activeDirectorySecurityRealm.getDescriptor().canDoNativeAuth() && activeDirectorySecurityRealm.domains == null) {
                         return true;
                     }
                 }

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -935,7 +935,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                 if (activeDirectorySecurityRealm.tlsConfiguration == null && activeDirectorySecurityRealm.getDescriptor().canDoNativeAuth() && activeDirectorySecurityRealm.domains != null) {
                     return true;
                 // AdministrativeMonitor in Unix environment if tlsConfiguration not saved
-                } else if (activeDirectorySecurityRealm.tlsConfiguration == null & !activeDirectorySecurityRealm.getDescriptor().canDoNativeAuth()) {
+                } else if (activeDirectorySecurityRealm.tlsConfiguration == null && !activeDirectorySecurityRealm.getDescriptor().canDoNativeAuth()) {
                     return true;
                 }
             }

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -928,15 +928,17 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     public static final class TlsConfigurationAdministrativeMonitor extends AdministrativeMonitor {
 
         public boolean isActivated() {
-                SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
-                if (securityRealm instanceof ActiveDirectorySecurityRealm) {
-                    ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) securityRealm;
-                    // AdministrativeMonitor only available if there is not any tlsConfiguration persistent on disk and not doing native authentication
-                    if (activeDirectorySecurityRealm.tlsConfiguration == null && !activeDirectorySecurityRealm.getDescriptor().canDoNativeAuth() && activeDirectorySecurityRealm.domains == null) {
-                        return true;
-                    }
+            SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
+            if (securityRealm instanceof ActiveDirectorySecurityRealm) {
+                ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) securityRealm;
+                // AdministrativeMonitor if native authentication, using customDomains and tlsConfiguration not saved
+                if (activeDirectorySecurityRealm.tlsConfiguration == null && activeDirectorySecurityRealm.getDescriptor().canDoNativeAuth() && activeDirectorySecurityRealm.domains != null) {
+                    return true;
+                // AdministrativeMonitor in Unix environment if tlsConfiguration not saved
+                } else if (activeDirectorySecurityRealm.tlsConfiguration == null & !activeDirectorySecurityRealm.getDescriptor().canDoNativeAuth()) {
+                    return true;
                 }
-
+            }
             return false;
         }
 

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/config.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/config.jelly
@@ -33,9 +33,10 @@
                 </div>
               </f:repeatable>
             </f:entry>
-            <st:include page="configCache.jelly" class="${descriptor.clazz}"/>
+            <st:include page="configAdvanced.jelly" class="${descriptor.clazz}"/>
           </f:optionalBlock>
         </table>
+        <st:include page="configCache.jelly" class="${descriptor.clazz}"/>
       </f:entry>
     </j:when>
     <j:otherwise>
@@ -69,6 +70,7 @@
         </f:repeatable>
       </f:entry>
       <st:include page="configAdvanced.jelly" class="${descriptor.clazz}"/>
+      <st:include page="configCache.jelly" class="${descriptor.clazz}"/>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
@@ -18,7 +18,6 @@
     <f:entry field="tlsConfiguration" title="${%TLS Configuration}">
       <f:select />
     </f:entry>
-    <st:include page="configCache.jelly" class="${descriptor.clazz}"/>
     <f:entry field="environmentProperties" title="${%Environment Properties}">
       <f:repeatableProperty field="environmentProperties" />
     </f:entry>


### PR DESCRIPTION
1. This issue only happens for users running Jenkins on Windows Servers
2. If Specify a custom Active Directory domain name is not selected. Then, the only issue here is that we should never show up the banner since we are doing native authentication.
3. If Specify a custom Active Directory domain name is selected, then we should show the Advanced section because we are not doing native authentication and at this point, ActiveDirectoryUnixAuthenticationProvider is used instead of ActiveDirectoryAuthenticationProvider.
4. Cache should be visible on al cases

* https://issues.jenkins-ci.org/browse/JENKINS-52045