### PR TITLE
[JENKINS-54267] Missing display name for administrative monitor

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -960,6 +960,11 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
         public static TlsConfigurationAdministrativeMonitor get() {
             return AdministrativeMonitor.all().get(TlsConfigurationAdministrativeMonitor.class);
         }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.TlsConfiguration_AdministrativeMonitor_DisplayName();
+        }
     }
 
 }

--- a/src/main/resources/hudson/plugins/active_directory/Messages.properties
+++ b/src/main/resources/hudson/plugins/active_directory/Messages.properties
@@ -11,3 +11,5 @@ ActiveDirectoryStatus.ActiveDirectoryHealthStatus = Active Directory Health Stat
 
 TlsConfiguration.TrustAllCertificates = (Unsecure) Trust all Certificates
 TlsConfiguration.JdkTrustStore = JDK TrustStore
+
+TlsConfiguration.AdministrativeMonitor.DisplayName =Active Directory TLS Configuration Monitor

--- a/src/main/resources/hudson/plugins/active_directory/Messages.properties
+++ b/src/main/resources/hudson/plugins/active_directory/Messages.properties
@@ -12,4 +12,4 @@ ActiveDirectoryStatus.ActiveDirectoryHealthStatus = Active Directory Health Stat
 TlsConfiguration.TrustAllCertificates = (Unsecure) Trust all Certificates
 TlsConfiguration.JdkTrustStore = JDK TrustStore
 
-TlsConfiguration.AdministrativeMonitor.DisplayName =Active Directory TLS Configuration Monitor
+TlsConfiguration.AdministrativeMonitor.DisplayName = Active Directory TLS Configuration Monitor


### PR DESCRIPTION
See [JENKINS-54267](https://issues.jenkins-ci.org/browse/JENKINS-54267)

The display name for the TLS configuration administrative monitor is missing.

![seleccion_004](https://user-images.githubusercontent.com/31063239/47561242-0241a100-d91b-11e8-9a51-9c9c38032d1a.png)

@reviewbybees 
@fbelzunc as maintainer of the plugin 