### PR TITLE
support for reverse proxy HTTP-Header based authentication

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
@@ -284,7 +284,7 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
             domains.add(domain);
 
             ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, site, bindName,
-                    bindPassword, null, GroupLookupStrategy.AUTO, false, true, null, false, (ActiveDirectoryInternalUsersDatabase) null);
+                    bindPassword, null, GroupLookupStrategy.AUTO, false, true, null, false, (ActiveDirectoryInternalUsersDatabase) null, null);
 
             ClassLoader ccl = Thread.currentThread().getContextClassLoader();
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
@@ -284,7 +284,7 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
             domains.add(domain);
 
             ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, site, bindName,
-                    bindPassword, null, GroupLookupStrategy.AUTO, false, true, null, false, (ActiveDirectoryInternalUsersDatabase) null, null);
+                    bindPassword, null, GroupLookupStrategy.AUTO, false, true, null, false, (ActiveDirectoryInternalUsersDatabase) null);
 
             ClassLoader ccl = Thread.currentThread().getContextClassLoader();
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
@@ -25,12 +25,18 @@ package hudson.plugins.active_directory;
  */
 
 import hudson.Extension;
-import hudson.Functions;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.acegisecurity.BadCredentialsException;
 import org.apache.commons.lang.StringUtils;
@@ -39,7 +45,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
-
 import javax.naming.CommunicationException;
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -49,13 +54,6 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.servlet.ServletException;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.toDC;
 
@@ -276,15 +274,21 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
         }
 
         @RequirePOST
-        public FormValidation doValidateTest(@QueryParameter(fixEmpty = true) String name, @QueryParameter(fixEmpty = true) String servers, @QueryParameter(fixEmpty = true) String site, @QueryParameter(fixEmpty = true) String bindName,
-                                             @QueryParameter(fixEmpty = true) String bindPassword, @QueryParameter(fixEmpty = true) TlsConfiguration tlsConfiguration) throws IOException, ServletException, NamingException {
+        public FormValidation doValidateTest(@QueryParameter(fixEmpty = true) String name,
+                                             @QueryParameter(fixEmpty = true) String servers,
+                                             @QueryParameter(fixEmpty = true) String site,
+                                             @QueryParameter(fixEmpty = true) String bindName,
+                                             @QueryParameter(fixEmpty = true) String bindPassword,
+                                             @QueryParameter(fixEmpty = true) TlsConfiguration tlsConfiguration)
+                throws IOException, ServletException, NamingException {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             ActiveDirectoryDomain domain = new ActiveDirectoryDomain(name, servers, site, bindName, bindPassword, tlsConfiguration);
             List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
             domains.add(domain);
 
             ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, site, bindName,
-                    bindPassword, null, GroupLookupStrategy.AUTO, false, true, null, false, (ActiveDirectoryInternalUsersDatabase) null);
+                    bindPassword, null, GroupLookupStrategy.AUTO, false, true,
+                    null, false, (ActiveDirectoryInternalUsersDatabase) null, null);
 
             ClassLoader ccl = Thread.currentThread().getContextClassLoader();
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -185,7 +185,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     /**
      * If not null, we check if this header exists and use the username in the header to load the user.
      */
-    protected String userFromHTTPHeader;
+    protected String userFromHttpHeader;
 
     /**
      * Regular expression, if set, extracts the username out of the given userFromHTTPHeader.
@@ -826,13 +826,13 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
         return getAuthenticationProvider().loadGroupByGroupname(groupname);
     }
 
-    public String getUserFromHTTPHeader() {
-        return userFromHTTPHeader;
+    public String getUserFromHttpHeader() {
+        return userFromHttpHeader;
     }
 
     @DataBoundSetter
-    public void setUserFromHTTPHeader(String userFromHTTPHeader) {
-        this.userFromHTTPHeader = userFromHTTPHeader;
+    public void setUserFromHttpHeader(String userFromHttpHeader) {
+        this.userFromHttpHeader = userFromHttpHeader;
     }
 
     public String getUsernameExtractionExpression() {

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -188,6 +188,11 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     protected String userFromHTTPHeader;
 
     /**
+     * Regular expression, if set, extracts the username out of the given userFromHTTPHeader.
+     */
+    protected String usernameExtractionExpression;
+
+    /**
      * Selects the SSL strategy to follow on the TLS connections
      *
      * <p>
@@ -828,6 +833,15 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     @DataBoundSetter
     public void setUserFromHTTPHeader(String userFromHTTPHeader) {
         this.userFromHTTPHeader = userFromHTTPHeader;
+    }
+
+    public String getUsernameExtractionExpression() {
+        return usernameExtractionExpression;
+    }
+
+    @DataBoundSetter
+    public void setUsernameExtractionExpression(String usernameExtractionExpression) {
+        this.usernameExtractionExpression = usernameExtractionExpression;
     }
 
     /**

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -46,7 +46,11 @@ import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.springframework.dao.DataAccessException;
 
@@ -230,15 +234,15 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                                         boolean removeIrrelevantGroups, Boolean customDomain, CacheConfiguration cache,
                                         Boolean startTls) {
         this(domain, domains, site, bindName, bindPassword, server, groupLookupStrategy, removeIrrelevantGroups,
-                customDomain, cache, startTls, TlsConfiguration.TRUST_ALL_CERTIFICATES, null);
+                customDomain, cache, startTls, TlsConfiguration.TRUST_ALL_CERTIFICATES);
     }
 
     public ActiveDirectorySecurityRealm(String domain, List<ActiveDirectoryDomain> domains, String site, String bindName,
                                         String bindPassword, String server, GroupLookupStrategy groupLookupStrategy,
                                         boolean removeIrrelevantGroups, Boolean customDomain, CacheConfiguration cache,
-                                        Boolean startTls, TlsConfiguration tlsConfiguration, String userFromHTTPHeader) {
+                                        Boolean startTls, TlsConfiguration tlsConfiguration) {
         this(domain, domains, site, bindName, bindPassword, server, groupLookupStrategy, removeIrrelevantGroups,
-                customDomain, cache, startTls, tlsConfiguration, null, userFromHTTPHeader);
+                customDomain, cache, startTls, tlsConfiguration, null);
     }
 
     @Deprecated
@@ -246,10 +250,9 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                                         String bindPassword, String server, GroupLookupStrategy groupLookupStrategy,
                                         boolean removeIrrelevantGroups, Boolean customDomain, CacheConfiguration cache,
                                         Boolean startTls, TlsConfiguration tlsConfiguration,
-                                        ActiveDirectoryInternalUsersDatabase internalUsersDatabase,
-                                        String userFromHTTPHeader) {
+                                        ActiveDirectoryInternalUsersDatabase internalUsersDatabase) {
         this(domain, domains, site, bindName, bindPassword, server, groupLookupStrategy, removeIrrelevantGroups,
-                customDomain, cache, startTls, (ActiveDirectoryInternalUsersDatabase) null, userFromHTTPHeader);
+                customDomain, cache, startTls, (ActiveDirectoryInternalUsersDatabase) null);
     }
 
 
@@ -258,8 +261,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     public ActiveDirectorySecurityRealm(String domain, List<ActiveDirectoryDomain> domains, String site, String bindName,
                                         String bindPassword, String server, GroupLookupStrategy groupLookupStrategy,
                                         boolean removeIrrelevantGroups, Boolean customDomain, CacheConfiguration cache,
-                                        Boolean startTls, ActiveDirectoryInternalUsersDatabase internalUsersDatabase,
-                                        String userFromHTTPHeader) {
+                                        Boolean startTls, ActiveDirectoryInternalUsersDatabase internalUsersDatabase) {
         if (customDomain!=null && !customDomain)
             domains = null;
         this.domain = fixEmpty(domain);
@@ -273,7 +275,6 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
         this.cache = cache;
         this.startTls = startTls;
         this.internalUsersDatabase = internalUsersDatabase;
-        this.userFromHTTPHeader = userFromHTTPHeader;
     }
 
     @DataBoundSetter
@@ -824,6 +825,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
         return userFromHTTPHeader;
     }
 
+    @DataBoundSetter
     public void setUserFromHTTPHeader(String userFromHTTPHeader) {
         this.userFromHTTPHeader = userFromHTTPHeader;
     }

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -190,7 +190,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     /**
      * Regular expression, if set, extracts the username out of the given userFromHTTPHeader.
      */
-    protected String usernameExtractionExpression;
+    protected Pattern usernameExtractionExpression;
 
     /**
      * Selects the SSL strategy to follow on the TLS connections
@@ -835,12 +835,12 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
         this.userFromHttpHeader = userFromHttpHeader;
     }
 
-    public String getUsernameExtractionExpression() {
+    public Pattern getUsernameExtractionExpression() {
         return usernameExtractionExpression;
     }
 
     @DataBoundSetter
-    public void setUsernameExtractionExpression(String usernameExtractionExpression) {
+    public void setUsernameExtractionExpression(Pattern usernameExtractionExpression) {
         this.usernameExtractionExpression = usernameExtractionExpression;
     }
 

--- a/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
+++ b/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
@@ -1,0 +1,63 @@
+package hudson.plugins.active_directory;
+
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.acegisecurity.userdetails.UserDetails;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class HttpHeaderFilter implements Filter {
+    private static final Logger LOGGER = Logger.getLogger(HttpHeaderFilter.class.getName());
+
+    private ActiveDirectorySecurityRealm activeDirectorySecurityRealm;
+
+    HttpHeaderFilter(ActiveDirectorySecurityRealm activeDirectorySecurityRealm) {
+        this.activeDirectorySecurityRealm = activeDirectorySecurityRealm;
+    }
+
+    public void doFilter(ServletRequest request,
+                         ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest r = (HttpServletRequest) request;
+
+        String userFromHeader;
+        Authentication auth = Jenkins.ANONYMOUS;
+        if ((getUserHeader() != null && (userFromHeader = r.getHeader(getUserHeader())) != null)) {
+            LOGGER.log(Level.FINE, "User from HTTP Header: {0}", userFromHeader);
+
+            try {
+                UserDetails userDetails = activeDirectorySecurityRealm.getAuthenticationProvider().loadUserByUsername(userFromHeader);
+
+                GrantedAuthority[] authorities = userDetails.getAuthorities();
+
+                auth = new UsernamePasswordAuthenticationToken(userFromHeader, "", authorities);
+            } catch (UsernameNotFoundException e) {
+                LOGGER.log(Level.FINE, "User from HTTP Header {0} not found in LDAP", userFromHeader);
+            }
+        }
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        chain.doFilter(r, response);
+    }
+
+    private String getUserHeader() {
+        return activeDirectorySecurityRealm.userFromHTTPHeader;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        /* No need to initialize or destroy */
+    }
+
+    @Override
+    public void destroy() {
+        /* No need to initialize or destroy */
+    }
+}

--- a/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
+++ b/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
@@ -12,7 +12,12 @@ import org.acegisecurity.providers.anonymous.AnonymousAuthenticationToken;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -32,8 +37,7 @@ class HttpHeaderFilter implements Filter {
             throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
 
-        if (SecurityContextHolder.getContext().getAuthentication() == null ||
-                SecurityContextHolder.getContext().getAuthentication() instanceof AnonymousAuthenticationToken) {
+        if (Jenkins.getAuthentication() instanceof AnonymousAuthenticationToken) {
             Authentication auth = Jenkins.ANONYMOUS;
             String authenticatedUserFromApiToken = getUserFromAuthorizationHeader(request);
 

--- a/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
+++ b/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
@@ -1,6 +1,9 @@
 package hudson.plugins.active_directory;
 
+import hudson.model.User;
+import hudson.util.Scrambler;
 import jenkins.model.Jenkins;
+import jenkins.security.ApiTokenProperty;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -23,28 +26,64 @@ class HttpHeaderFilter implements Filter {
         this.activeDirectorySecurityRealm = activeDirectorySecurityRealm;
     }
 
-    public void doFilter(ServletRequest request,
+    public void doFilter(ServletRequest servletRequest,
                          ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        HttpServletRequest r = (HttpServletRequest) request;
-
-        String userFromHeader;
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
         Authentication auth = Jenkins.ANONYMOUS;
-        if ((getUserHeader() != null && (userFromHeader = r.getHeader(getUserHeader())) != null)) {
-            LOGGER.log(Level.FINE, "User from HTTP Header: {0}", userFromHeader);
+        String authenticatedUserFromApiToken = getUserFromAuthorizationHeader(request);
 
+        String userName = authenticatedUserFromApiToken == null ? getUserFromReverseProxyHeader(request) : authenticatedUserFromApiToken;
+        if (userName != null) {
             try {
-                UserDetails userDetails = activeDirectorySecurityRealm.getAuthenticationProvider().loadUserByUsername(userFromHeader);
+                UserDetails userDetails = activeDirectorySecurityRealm.getAuthenticationProvider().loadUserByUsername(userName);
 
                 GrantedAuthority[] authorities = userDetails.getAuthorities();
 
-                auth = new UsernamePasswordAuthenticationToken(userFromHeader, "", authorities);
+                auth = new UsernamePasswordAuthenticationToken(userName, "", authorities);
             } catch (UsernameNotFoundException e) {
-                LOGGER.log(Level.FINE, "User from HTTP Header {0} not found in LDAP", userFromHeader);
+                LOGGER.log(Level.FINE, "User from HTTP Header {0} not found in LDAP", userName);
             }
         }
+
         SecurityContextHolder.getContext().setAuthentication(auth);
-        chain.doFilter(r, response);
+        chain.doFilter(request, response);
+    }
+
+    private String getUserFromAuthorizationHeader(HttpServletRequest request) {
+        String authorization;
+        if ((authorization = request.getHeader("Authorization")) != null && authorization.toLowerCase().startsWith("basic ")) {
+            String uidpassword = Scrambler.descramble(authorization.substring(6));
+            int idx = uidpassword.indexOf(':');
+            if (idx >= 0) {
+                String username = uidpassword.substring(0, idx);
+                String password = uidpassword.substring(idx + 1);
+
+                // attempt to authenticate as API token
+                User u = User.get(username, false);
+                if (u != null) {
+                    ApiTokenProperty t = u.getProperty(ApiTokenProperty.class);
+                    if (t != null && t.matchesPassword(password)) { // Authenticate API-Token
+                        return username;
+                    } else { // Authenticate against LDAP
+                        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(username, password);
+                        UserDetails details = activeDirectorySecurityRealm.getAuthenticationProvider().retrieveUser(username, auth);
+                        if (details != null)
+                            return username;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private String getUserFromReverseProxyHeader(HttpServletRequest request) {
+        String userFromHeader;
+        if ((getUserHeader() != null && (userFromHeader = request.getHeader(getUserHeader())) != null)) {
+            LOGGER.log(Level.FINE, "User from HTTP Header: {0}", userFromHeader);
+            return userFromHeader;
+        }
+        return null;
     }
 
     private String getUserHeader() {

--- a/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
+++ b/src/main/java/hudson/plugins/active_directory/HttpHeaderFilter.java
@@ -6,6 +6,7 @@ import hudson.security.ACLContext;
 import hudson.util.Scrambler;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -65,7 +66,7 @@ class HttpHeaderFilter implements Filter {
 
     String getUserFromAuthorizationHeader(HttpServletRequest request) {
         String authorization;
-        if ((authorization = request.getHeader("Authorization")) != null && authorization.toLowerCase().startsWith("basic ")) {
+        if ((authorization = request.getHeader("Authorization")) != null && authorization.toLowerCase(Locale.ROOT).startsWith("basic ")) {
             String uidpassword = Scrambler.descramble(authorization.substring(6));
             int idx = uidpassword.indexOf(':');
             if (idx >= 0) {

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
@@ -1,6 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:advanced>
+    <f:entry field="userFromHTTPHeader" title="${%Use HTTP-Header as username provider. Example: 'X-Forwarded-User'}">
+      <f:textbox />
+    </f:entry>
     <f:entry field="startTls" title="${%Enable StartTls}">
       <f:checkbox name="startTls" default="true" />
     </f:entry>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:advanced>
-    <f:entry field="userFromHTTPHeader" title="${%Use HTTP-Header as username provider. Example: 'X-Forwarded-User'}">
+    <f:entry field="userFromHttpHeader" title="${%Use HTTP-Header as username provider}">
       <f:textbox />
     </f:entry>
     <f:entry field="usernameExtractionExpression" title="${%Regular expression with one capture group to extract the username out of the HTTP-Header}">

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
@@ -4,6 +4,9 @@
     <f:entry field="userFromHTTPHeader" title="${%Use HTTP-Header as username provider. Example: 'X-Forwarded-User'}">
       <f:textbox />
     </f:entry>
+    <f:entry field="usernameExtractionExpression" title="${%Regular expression with one capture group to extract the username out of the HTTP-Header}">
+      <f:textbox />
+    </f:entry>
     <f:entry field="startTls" title="${%Enable StartTls}">
       <f:checkbox name="startTls" default="true" />
     </f:entry>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.properties
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.properties
@@ -1,0 +1,1 @@
+Use\ HTTP-Header\ as\ username\ provider=Use HTTP-Header as username provider Example: 'X-Forwarded-User'

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-userFromHTTPHeader.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-userFromHTTPHeader.html
@@ -1,0 +1,8 @@
+<div>
+    Authenticates the user in Jenkins via a HTTP header field.
+    You can disable the behaviour if set this value to "".
+
+    SECURITY WARNING: Please make sure that this header cannot be provided
+        by end-users and is only provided by a valid, authorized and secured reverse-proxy.
+        Otherwise the users will simply be logged in as the provided user, without validating any password.
+</div>

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-userFromHttpHeader.html
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/help-userFromHttpHeader.html
@@ -2,7 +2,8 @@
     Authenticates the user in Jenkins via a HTTP header field.
     You can disable the behaviour if set this value to "".
 
-    SECURITY WARNING: Please make sure that this header cannot be provided
+    <strong class="warning-inline">SECURITY WARNING: Please make sure that this header cannot be provided
         by end-users and is only provided by a valid, authorized and secured reverse-proxy.
         Otherwise the users will simply be logged in as the provided user, without validating any password.
+    </strong>
 </div>

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealmTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealmTest.java
@@ -4,15 +4,14 @@ import com.gargoylesoftware.htmlunit.html.DomElement;
 import hudson.plugins.active_directory.docker.TheFlintstonesTest;
 import hudson.security.HudsonPrivateSecurityRealm;
 import hudson.security.SecurityRealm;
+import java.util.ArrayList;
+import java.util.List;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -287,10 +286,14 @@ public class ActiveDirectorySecurityRealmTest {
     @Issue("JENKINS-46884")
     @Test
     public void testAdvancedOptionsVisibleWithNonNativeAuthentication() throws Exception {
-        ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN, null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
+        ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN,
+                null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains,
+                null, null, null, null, GroupLookupStrategy.RECURSIVE,
+                false, true, null, false, (ActiveDirectoryInternalUsersDatabase) null,
+                null);
         Jenkins.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         DomElement domElement = jenkinsRule.createWebClient().goTo("configureSecurity").getElementByName("startTls");
         assertTrue(domElement != null);
@@ -299,10 +302,14 @@ public class ActiveDirectorySecurityRealmTest {
     @Issue("JENKINS-46884")
     @Test
     public void testCacheOptionAlwaysVisible() throws Exception {
-        ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN, null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
+        ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN,
+                null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains,
+                null, null, null, null, GroupLookupStrategy.RECURSIVE,
+                false, true, null, false, (ActiveDirectoryInternalUsersDatabase) null,
+                null);
         Jenkins.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         DomElement domElement = jenkinsRule.createWebClient().goTo("configureSecurity").getElementByName("cache");
         assertTrue(domElement != null);

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealmTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealmTest.java
@@ -1,7 +1,6 @@
 package hudson.plugins.active_directory;
 
 import com.gargoylesoftware.htmlunit.html.DomElement;
-import hudson.model.AdministrativeMonitor;
 import hudson.plugins.active_directory.docker.TheFlintstonesTest;
 import hudson.security.HudsonPrivateSecurityRealm;
 import hudson.security.SecurityRealm;
@@ -21,8 +20,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-
 
 public class ActiveDirectorySecurityRealmTest {
 
@@ -293,7 +290,7 @@ public class ActiveDirectorySecurityRealmTest {
         ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN, null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null, null);
         Jenkins.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         DomElement domElement = jenkinsRule.createWebClient().goTo("configureSecurity").getElementByName("startTls");
         assertTrue(domElement != null);
@@ -305,7 +302,7 @@ public class ActiveDirectorySecurityRealmTest {
         ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN, null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null, null);
         Jenkins.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         DomElement domElement = jenkinsRule.createWebClient().goTo("configureSecurity").getElementByName("cache");
         assertTrue(domElement != null);

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealmTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealmTest.java
@@ -290,7 +290,7 @@ public class ActiveDirectorySecurityRealmTest {
         ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN, null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
         Jenkins.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         DomElement domElement = jenkinsRule.createWebClient().goTo("configureSecurity").getElementByName("startTls");
         assertTrue(domElement != null);
@@ -302,7 +302,7 @@ public class ActiveDirectorySecurityRealmTest {
         ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(TheFlintstonesTest.AD_DOMAIN, null, null, TheFlintstonesTest.AD_MANAGER_DN, TheFlintstonesTest.AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
         Jenkins.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         DomElement domElement = jenkinsRule.createWebClient().goTo("configureSecurity").getElementByName("cache");
         assertTrue(domElement != null);

--- a/src/test/java/hudson/plugins/active_directory/HttpHeaderFilterTest.java
+++ b/src/test/java/hudson/plugins/active_directory/HttpHeaderFilterTest.java
@@ -1,0 +1,61 @@
+package hudson.plugins.active_directory;
+
+import hudson.util.Secret;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Secret.class})
+public class HttpHeaderFilterTest {
+
+    @Before
+    public void setup() {
+        PowerMockito.mockStatic(Secret.class);
+        when(Secret.fromString(anyString())).thenReturn(mock(Secret.class));
+    }
+
+    @Test
+    public void testNoRegex() {
+        String headerField = "x-user-name";
+        String username = "CN=abcde,OU=yes,C=no";
+
+        HttpHeaderFilter filter = new HttpHeaderFilter(new TestRealm(headerField, ""));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader(headerField)).thenReturn(username);
+
+        String result = filter.getUserFromReverseProxyHeader(request);
+        assertEquals("CN=abcde,OU=yes,C=no", result);
+    }
+
+    @Test
+    public void testWithRegex() {
+        String headerField = "x-user-name";
+        String username = "CN=abcde,OU=yes,C=no";
+
+        HttpHeaderFilter filter = new HttpHeaderFilter(new TestRealm(headerField, "^CN=([^,]*).*"));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader(headerField)).thenReturn(username);
+
+        String result = filter.getUserFromReverseProxyHeader(request);
+        assertEquals("abcde", result);
+    }
+
+    static class TestRealm extends ActiveDirectorySecurityRealm {
+        TestRealm(String headerField, String regex) {
+            super("", "", "", "", "");
+            setUserFromHTTPHeader(headerField);
+            setUsernameExtractionExpression(regex);
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/active_directory/HttpHeaderFilterTest.java
+++ b/src/test/java/hudson/plugins/active_directory/HttpHeaderFilterTest.java
@@ -54,7 +54,7 @@ public class HttpHeaderFilterTest {
     static class TestRealm extends ActiveDirectorySecurityRealm {
         TestRealm(String headerField, String regex) {
             super("", "", "", "", "");
-            setUserFromHTTPHeader(headerField);
+            setUserFromHttpHeader(headerField);
             setUsernameExtractionExpression(regex);
         }
     }

--- a/src/test/java/hudson/plugins/active_directory/HttpHeaderFilterTest.java
+++ b/src/test/java/hudson/plugins/active_directory/HttpHeaderFilterTest.java
@@ -1,14 +1,14 @@
 package hudson.plugins.active_directory;
 
 import hudson.util.Secret;
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import javax.servlet.http.HttpServletRequest;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -30,7 +30,7 @@ public class HttpHeaderFilterTest {
         String headerField = "x-user-name";
         String username = "CN=abcde,OU=yes,C=no";
 
-        HttpHeaderFilter filter = new HttpHeaderFilter(new TestRealm(headerField, ""));
+        HttpHeaderFilter filter = new HttpHeaderFilter(new TestRealm(headerField, Pattern.compile("")));
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getHeader(headerField)).thenReturn(username);
 
@@ -43,7 +43,7 @@ public class HttpHeaderFilterTest {
         String headerField = "x-user-name";
         String username = "CN=abcde,OU=yes,C=no";
 
-        HttpHeaderFilter filter = new HttpHeaderFilter(new TestRealm(headerField, "^CN=([^,]*).*"));
+        HttpHeaderFilter filter = new HttpHeaderFilter(new TestRealm(headerField, Pattern.compile("^CN=([^,]*).*")));
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getHeader(headerField)).thenReturn(username);
 
@@ -52,7 +52,7 @@ public class HttpHeaderFilterTest {
     }
 
     static class TestRealm extends ActiveDirectorySecurityRealm {
-        TestRealm(String headerField, String regex) {
+        TestRealm(String headerField, Pattern regex) {
             super("", "", "", "", "");
             setUserFromHttpHeader(headerField);
             setUsernameExtractionExpression(regex);

--- a/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheDisabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheDisabledTest.java
@@ -1,15 +1,14 @@
 package hudson.plugins.active_directory;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import java.io.File;
+import java.util.List;
+import java.util.logging.Level;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
-
-import java.io.File;
-import java.util.List;
-import java.util.logging.Level;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -34,14 +33,14 @@ public class WindowsAdsiModeUserCacheDisabledTest {
     public void dynamicCacheEnableSetUp() throws Exception {
         CacheConfiguration cacheConfiguration = new CacheConfiguration(500,30);
         ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, null, null, null,
-                null, null, null, false, null, cacheConfiguration, null, (ActiveDirectoryInternalUsersDatabase) null);
+                null, null, null, false, null, cacheConfiguration, null, (ActiveDirectoryInternalUsersDatabase) null, null);
         j.jenkins.setSecurityRealm(activeDirectorySecurityRealm);
     }
 
 
     public void dynamicCacheDisabledSetUp() throws Exception {
         ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, null, null, null,
-                null, null, null, false, null, null, null, (ActiveDirectoryInternalUsersDatabase) null);
+                null, null, null, false, null, null, null, (ActiveDirectoryInternalUsersDatabase) null, null);
         j.jenkins.setSecurityRealm(activeDirectorySecurityRealm);
     }
 

--- a/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheEnabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheEnabledTest.java
@@ -1,16 +1,15 @@
 package hudson.plugins.active_directory;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import java.io.File;
+import java.util.List;
+import java.util.logging.Level;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
-
-import java.io.File;
-import java.util.List;
-import java.util.logging.Level;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -53,14 +52,16 @@ public class WindowsAdsiModeUserCacheEnabledTest {
     public void dynamicCacheEnableSetUp() throws Exception {
         CacheConfiguration cacheConfiguration = new CacheConfiguration(500,30);
         ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, null, null, null,
-                null, null, null, false, null, cacheConfiguration, null, (ActiveDirectoryInternalUsersDatabase) null);
+                null, null, null, false, null, cacheConfiguration, null,
+                (ActiveDirectoryInternalUsersDatabase) null, null);
         j.jenkins.setSecurityRealm(activeDirectorySecurityRealm);
     }
 
 
     public void dynamicCacheDisabledSetUp() throws Exception {
         ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, null, null, null,
-                null, null, null, false, null, null, null, (ActiveDirectoryInternalUsersDatabase) null);
+                null, null, null, false, null, null, null,
+                (ActiveDirectoryInternalUsersDatabase) null, null);
         j.jenkins.setSecurityRealm(activeDirectorySecurityRealm);
     }
 

--- a/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupDisabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupDisabledTest.java
@@ -6,6 +6,9 @@ import hudson.plugins.active_directory.ActiveDirectoryInternalUsersDatabase;
 import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
 import hudson.plugins.active_directory.CacheConfiguration;
 import hudson.plugins.active_directory.GroupLookupStrategy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.userdetails.UserDetails;
 import org.apache.commons.io.FileUtils;
@@ -16,10 +19,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -55,7 +54,9 @@ public class EntoEndUserCacheLookupDisabledTest {
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
 
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, site, bindName, bindPassword, null, groupLookupStrategy, removeIrrelevantGroups, customDomain, cache, startTls, internalUsersDatabase);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains,
+                site, bindName, bindPassword, null, groupLookupStrategy, removeIrrelevantGroups, customDomain, cache,
+                startTls, internalUsersDatabase, null);
         j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         while(!FileUtils.readFileToString(d.getLogfile()).contains("custom (exit status 0; expected)")) {
             Thread.sleep(1000);

--- a/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
@@ -7,6 +7,9 @@ import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
 import hudson.plugins.active_directory.CacheConfiguration;
 import hudson.plugins.active_directory.CacheUtil;
 import hudson.plugins.active_directory.GroupLookupStrategy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.userdetails.UserDetails;
 import org.apache.commons.io.FileUtils;
@@ -19,10 +22,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -76,7 +75,9 @@ public class EntoEndUserCacheLookupEnabledTest {
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
 
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, site, bindName, bindPassword, null, groupLookupStrategy, removeIrrelevantGroups, customDomain, cache, startTls, internalUsersDatabase);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains,
+                site, bindName, bindPassword, null, groupLookupStrategy, removeIrrelevantGroups, customDomain,
+                cache, startTls, internalUsersDatabase, null);
         j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         while(!FileUtils.readFileToString(d.getLogfile()).contains("custom (exit status 0; expected)")) {
             Thread.sleep(1000);

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -25,11 +25,15 @@
 package hudson.plugins.active_directory.docker;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Collections2;
 import hudson.plugins.active_directory.ActiveDirectoryDomain;
 import hudson.plugins.active_directory.ActiveDirectoryInternalUsersDatabase;
 import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
 import hudson.plugins.active_directory.CacheConfiguration;
 import hudson.plugins.active_directory.GroupLookupStrategy;
+import hudson.security.GroupDetails;
+import hudson.util.RingBufferLogHandler;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.acegisecurity.AuthenticationServiceException;
@@ -39,11 +43,11 @@ import org.apache.commons.io.FileUtils;
 import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.test.acceptance.docker.DockerRule;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 import javax.naming.CommunicationException;
 import javax.naming.NamingException;
@@ -52,6 +56,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.*;
 
 import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.Matchers.contains;
@@ -104,7 +109,7 @@ public class TheFlintstonesTest {
         ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(AD_DOMAIN, dockerIp + ":" +  dockerPort , null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null, null);
         j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         while(!FileUtils.readFileToString(d.getLogfile()).contains("custom (exit status 0; expected)")) {
             Thread.sleep(1000);

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -50,13 +50,14 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 import javax.naming.CommunicationException;
-import javax.naming.NamingException;
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.*;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 
 import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.Matchers.contains;
@@ -109,7 +110,7 @@ public class TheFlintstonesTest {
         ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(AD_DOMAIN, dockerIp + ":" +  dockerPort , null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
         j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         while(!FileUtils.readFileToString(d.getLogfile()).contains("custom (exit status 0; expected)")) {
             Thread.sleep(1000);
@@ -206,7 +207,7 @@ public class TheFlintstonesTest {
 
     @Issue("JENKINS-36148")
     @Test
-    public void validateCustomDomainController() throws ServletException, NamingException, IOException, Exception {
+    public void validateCustomDomainController() throws Exception {
         dynamicSetUp();
         ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
         assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, dockerIp + ":" + dockerPort, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null).toString().trim());
@@ -214,7 +215,7 @@ public class TheFlintstonesTest {
 
     @Issue("JENKINS-36148")
     @Test
-    public void validateDomain() throws ServletException, NamingException, IOException, Exception {
+    public void validateDomain() throws Exception {
         dynamicSetUp();
         ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
         assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, null, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null).toString().trim());

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -28,13 +28,19 @@ import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import hudson.plugins.active_directory.ActiveDirectoryDomain;
-import hudson.plugins.active_directory.ActiveDirectoryInternalUsersDatabase;
 import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
-import hudson.plugins.active_directory.CacheConfiguration;
 import hudson.plugins.active_directory.GroupLookupStrategy;
 import hudson.security.GroupDetails;
 import hudson.util.RingBufferLogHandler;
 import hudson.util.Secret;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 import jenkins.model.Jenkins;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.userdetails.UserDetails;
@@ -47,40 +53,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.recipes.LocalData;
-
-import javax.naming.CommunicationException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Formatter;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
-
-import static junit.framework.Assert.assertEquals;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsStringIgnoringCase;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.logging.Formatter;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
-
-import com.google.common.base.Predicates;
-import com.google.common.collect.Collections2;
-
-import hudson.security.GroupDetails;
-import hudson.util.RingBufferLogHandler;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.recipes.LocalData;
+import javax.naming.CommunicationException;
+
+import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration tests with Docker
@@ -110,7 +92,10 @@ public class TheFlintstonesTest {
         ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(AD_DOMAIN, dockerIp + ":" +  dockerPort , null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD);
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
         domains.add(activeDirectoryDomain);
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, null);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains,
+                null, null, null, null, GroupLookupStrategy.RECURSIVE,
+                false, true, null, false, null,
+                (String) null);
         j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
         while(!FileUtils.readFileToString(d.getLogfile()).contains("custom (exit status 0; expected)")) {
             Thread.sleep(1000);


### PR DESCRIPTION
This adds a feature similar to what https://github.com/jenkinsci/reverse-proxy-auth-plugin already implements. I couldn't use that plugin however, because of https://issues.jenkins-ci.org/browse/JENKINS-29330 
I turned out to be much simpler to add the reverse-proxy authentication into *this* plugin than to add the recursive group lookup into the reverse-proxy plugin.