### PR TITLE
Add test for CasC compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.40</version>
+    <version>3.56</version>
   </parent>
 
   <artifactId>active-directory</artifactId>
@@ -35,6 +35,7 @@
   <properties>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
+    <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
 
   <dependencies>
@@ -73,13 +74,18 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.25.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
@@ -101,7 +107,30 @@
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <!-- JCasC compatibility -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${configuration-as-code.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>${configuration-as-code.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityTest.java
@@ -71,5 +71,4 @@ public class ActiveDirectoryJCasCCompatibilityTest extends RoundTripAbstractTest
     protected String stringInLogExpected() {
         return "Setting class hudson.plugins.active_directory.ActiveDirectorySecurityRealm.groupLookupStrategy = RECURSIVE";
     }
-    
 }

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityTest.java
@@ -1,0 +1,74 @@
+package hudson.plugins.active_directory;
+
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.RuleChain;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ActiveDirectoryJCasCCompatibilityTest extends RoundTripAbstractTest {
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
+            .set("BIND_PASSWORD_1", "PASSW1")
+            .set("BIND_PASSWORD_2", "PASSW2"));
+
+    @Before
+    public void setUp() {
+        chain.around(r.j);
+    }
+
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        final Jenkins jenkins = Jenkins.getInstance();
+        final ActiveDirectorySecurityRealm realm = (ActiveDirectorySecurityRealm) jenkins.getSecurityRealm();
+
+        assertEquals(2, realm.domains.size());
+        // First domain
+        ActiveDirectoryDomain domain = realm.domains.get(0);
+        assertEquals("acme", domain.name);
+        assertEquals("admin", domain.bindName);
+        assertEquals("ad1.acme.com:123,ad2.acme.com:456", domain.servers);
+        assertEquals("site", domain.getSite());
+        assertEquals("PASSW1", domain.getBindPassword().getPlainText());
+        assertEquals(TlsConfiguration.JDK_TRUSTSTORE, domain.getTlsConfiguration());
+        // Second domain
+        domain = realm.domains.get(1);
+        assertEquals("acme2", domain.name);
+        assertEquals("admin", domain.bindName);
+        assertEquals("ad1.acme2.com:123,ad2.acme2.com:456", domain.servers);
+        assertEquals("site2", domain.getSite());
+        assertEquals("PASSW2", domain.getBindPassword().getPlainText());
+        assertEquals(TlsConfiguration.TRUST_ALL_CERTIFICATES, domain.getTlsConfiguration());
+
+        assertEquals(2, realm.getEnvironmentProperties().size());
+        // First Env Property
+        ActiveDirectorySecurityRealm.EnvironmentProperty prop = realm.getEnvironmentProperties().get(0);
+        assertEquals("prop1", prop.getName());
+        assertEquals("value1", prop.getValue());
+        // Second Env Property
+        prop = realm.getEnvironmentProperties().get(1);
+        assertEquals("prop2", prop.getName());
+        assertEquals("value2", prop.getValue());
+
+        // General properties
+        assertTrue(realm.removeIrrelevantGroups);
+        assertTrue(realm.startTls);
+        assertEquals("jenkins", realm.getJenkinsInternalUser());
+        assertEquals(GroupLookupStrategy.RECURSIVE, realm.getGroupLookupStrategy());
+        assertNotNull(realm.getCache());
+        assertEquals(500, realm.getCache().getSize());
+        assertEquals(600, realm.getCache().getTtl());
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "Setting class hudson.plugins.active_directory.ActiveDirectorySecurityRealm.groupLookupStrategy = RECURSIVE";
+    }
+}

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityTest.java
@@ -71,4 +71,5 @@ public class ActiveDirectoryJCasCCompatibilityTest extends RoundTripAbstractTest
     protected String stringInLogExpected() {
         return "Setting class hudson.plugins.active_directory.ActiveDirectorySecurityRealm.groupLookupStrategy = RECURSIVE";
     }
+    
 }

--- a/src/test/resources/hudson/plugins/active_directory/configuration-as-code.yaml
+++ b/src/test/resources/hudson/plugins/active_directory/configuration-as-code.yaml
@@ -1,0 +1,30 @@
+jenkins:
+  securityRealm:
+    activeDirectory:
+      cache:
+        size: 500
+        ttl: 600
+      customDomain: true
+      domains:
+        - bindName: "admin"
+          bindPassword: "${BIND_PASSWORD_1}"
+          name: "acme"
+          servers: "ad1.acme.com:123,ad2.acme.com:456"
+          site: "site"
+          tlsConfiguration: JDK_TRUSTSTORE
+        - bindName: "admin"
+          bindPassword: "${BIND_PASSWORD_2}"
+          name: "acme2"
+          servers: "ad1.acme2.com:123,ad2.acme2.com:456"
+          site: "site2"
+          tlsConfiguration: TRUST_ALL_CERTIFICATES
+      environmentProperties:
+        - name: "prop1"
+          value: "value1"
+        - name: "prop2"
+          value: "value2"
+      groupLookupStrategy: RECURSIVE
+      internalUsersDatabase:
+        jenkinsInternalUser: "jenkins"
+      removeIrrelevantGroups: true
+      startTls: true


### PR DESCRIPTION
`active-directory-plugin` is compatible with CasC. That plugin has an [integration test](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/integrations/src/test/java/io/jenkins/plugins/casc/ActiveDirectoryTest.java), but it's fixed to an old version. Although I plan to update it as well, this PR intends to include a test in this same plugin so in case any change broke the compatibility, it can be fixed immediately