### PR TITLE
Categorize AD Health Status

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryStatus.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryStatus.java
@@ -150,6 +150,12 @@ public class ActiveDirectoryStatus extends ManagementLink implements StaplerProx
         return this;
     }
 
+    @NonNull
+    @Override
+    public Category getCategory() {
+        return Category.STATUS; // AD would be SECURITY, but here it's more a "health status" indeed.
+    }
+
     /**
      * ServerHealth of a SocketInfo
      */


### PR DESCRIPTION
Appears "uncategorized" before this change.

## Before:
![image](https://user-images.githubusercontent.com/223853/102025473-68f2d480-3d98-11eb-80cd-0e65c32f56fe.png)


## After/with this change:

![image](https://user-images.githubusercontent.com/223853/102025485-832cb280-3d98-11eb-875f-02fe44939452.png)
