### PR TITLE
[JENKINS-68947] Active Directory plugin fails on Java 17 with `IllegalAccessError`: "module `java.naming` does not export `com.sun.jndi.ldap` to unnamed module"

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.2</version>
+    <version>1.4</version>
   </extension>
 </extensions>


### PR DESCRIPTION
Tentative fix for [JENKINS-68947](https://issues.jenkins.io/browse/JENKINS-68947) pending testing. See self-review for an explanation of the changes.