### PR TITLE
Bump parent from 4.19 to 4.47 to fix flakiness in WindowsAdsiModeUserCacheDisabledTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.19</version>
+    <version>4.47</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Bump parent from 4.19 to 4.47 to fix flakiness in WindowsAdsiModeUserCacheDisabledTest
