### PR TITLE
Bump jenkins baseline to 2.319.3, parent pom and needed dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(configurations: [
-    [platform: 'linux', jdk: '8'],
     [platform: 'linux', jdk: '11'],
     [platform: 'windows', jdk: '11'],
 ])
@@ -8,12 +7,11 @@ node('docker') {
      stage('checkout') {
         checkout scm
      }
-     stage('docker-pull') {
-        sh 'docker pull fbelzunc/ad-build-container-with-docker-fixtures'
-     }
+
      stage('maven') {
-        sh 'docker run --add-host=samdom.example.com:127.0.0.1 -v /var/lib/docker --privileged --dns=127.0.0.1 --dns=8.8.8.8 -v $WORKSPACE:/project  fbelzunc/ad-build-container-with-docker-fixtures clean install -P \'!noIT\''
+        sh 'docker build -t fixture src/test/resources/fixture && docker run --add-host=samdom.example.com:127.0.0.1 -v /var/lib/docker --privileged --dns=127.0.0.1 --dns=8.8.8.8 -v $WORKSPACE:/project fixture clean install -P \'!noIT\''
      }
+
      stage('surefire-report') {
         junit 'target/surefire-reports/*.xml'
      }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.19</version>
+    <version>4.50</version>
     <relativePath />
   </parent>
 
@@ -37,9 +37,9 @@
     <revision>2.28</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.235.5</jenkins.version>
+    <jenkins.version>2.319.3</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code.version>1.35</configuration-as-code.version>
+    <configuration-as-code.version>1569.vb_72405b_80249</configuration-as-code.version>
   </properties>
 
   <dependencies>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
-      <version>2.9.0-17.v79e9099a51e3</version>
+      <version>2.9.3-65.v6a_47d0f4d1fe</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
-      <version>1.10</version>
+      <version>166.v912b_95083ffe</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,20 @@
     <revision>2.28</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.319.3</jenkins.version>
-    <java.level>8</java.level>
-    <configuration-as-code.version>1569.vb_72405b_80249</configuration-as-code.version>
+    <jenkins.version>2.332.4</jenkins.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1678.vc1feb_6a_3c0f1</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -73,12 +83,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
-      <version>2.9.3-65.v6a_47d0f4d1fe</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
@@ -123,13 +131,11 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/resources/fixture/Dockerfile
+++ b/src/test/resources/fixture/Dockerfile
@@ -1,0 +1,25 @@
+FROM docker:stable-dind
+# Keys were rotated in the edge repos, so we need to do this now
+RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.16/main -u alpine-keys --allow-untrusted
+# Workaround for  https://github.com/AdoptOpenJDK/openjdk-docker/issues/75
+RUN apk add --no-cache fontconfig ttf-dejavu openjdk11 bash tini bind-tools
+RUN apk add aufs-util --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add maven --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
+# Workaround for  https://github.com/AdoptOpenJDK/openjdk-docker/issues/75
+RUN ln -s /usr/lib/libfontconfig.so.1 /usr/lib/libfontconfig.so && \
+    ln -s /lib/libuuid.so.1 /usr/lib/libuuid.so.1 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /usr/lib/libc.musl-x86_64.so.1
+ENV LD_LIBRARY_PATH /usr/lib
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk/
+#ENV DOCKER_STORAGE_DRIVER=overlay2
+ENV DOCKER_HOST=unix:///var/tmp/docker.sock
+
+COPY daemon.json /etc/docker/daemon.json
+COPY custom-dockerd-entrypoint.sh /usr/local/bin/custom-dockerd-entrypoint.sh
+
+WORKDIR /project
+
+ENTRYPOINT ["/sbin/tini","-g","--","bash","/usr/local/bin/custom-dockerd-entrypoint.sh"]
+
+CMD ["clean","install"]

--- a/src/test/resources/fixture/custom-dockerd-entrypoint.sh
+++ b/src/test/resources/fixture/custom-dockerd-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex -o pipefail
+DOCKER_OPTS="--config-file=/etc/docker/daemon.json"
+$(which dind) dockerd ${DOCKER_OPTS} >/dev/stdout 2>&1 &
+sleep 1
+mvn -B -Djenkins.test.timeout=1200 "$@"
+exit 0

--- a/src/test/resources/fixture/daemon.json
+++ b/src/test/resources/fixture/daemon.json
@@ -1,0 +1,10 @@
+{
+  "hosts": [
+    "unix:///var/tmp/docker.sock",
+    "tcp://0.0.0.0:2375"
+  ],
+  "insecure-registries": [
+    "docker-registry:5000"
+  ],
+  "bip":"192.168.0.1/24"
+}


### PR DESCRIPTION
There were failures in PCT runs against the upcoming 2.375.1 LTS due to out of date test dependencies.

Reproduced by `mvn test -Djenkins.version=2.375`  
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
