### PR TITLE
Switch test containers to dynamic ports for non integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(configurations: [
     [platform: 'linux', jdk: '11'],
     [platform: 'windows', jdk: '11'],
-])
+], useContainerAgent: false)
 
 node('docker') {
      stage('checkout') {
@@ -9,7 +9,7 @@ node('docker') {
      }
 
      stage('maven') {
-        sh 'docker build -t fixture src/test/resources/fixture && docker run --add-host=samdom.example.com:127.0.0.1 -v /var/lib/docker --privileged --dns=127.0.0.1 --dns=8.8.8.8 -v $WORKSPACE:/project fixture clean install -P \'!noIT\''
+        sh 'docker build -t fixture src/test/resources/fixture && docker run --add-host=samdom.example.com:127.0.0.1 -v /var/lib/docker --privileged --dns=127.0.0.1 --dns=8.8.8.8 -v $WORKSPACE:/project fixture clean install -P onlyITs'
      }
 
      stage('surefire-report') {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
    <url>https://github.com/${gitHubRepo}</url>
-   <tag>active-directory-2.29</tag>
+   <tag>HEAD</tag>
   </scm>
 
   <developers>
@@ -91,7 +91,6 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.5.1</version>
       <optional>true</optional>
       <exclusions>
         <exclusion>
@@ -103,7 +102,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.4.0</version>
       <scope>test</scope>
     </dependency>
     <!-- For docker integration tests -->
@@ -148,38 +146,55 @@
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-surefire-plugin</artifactId>
          <configuration>
-           <!--<forkCount>2C</forkCount>-->
-           <!--<reuseForks>false</reuseForks>-->
            <argLine>-Xms2048m -Xmx2048m</argLine>
          </configuration>
        </plugin>
      </plugins>
   </build>
-
+  
   <profiles>
     <profile>
-      <id>noIT</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
+      <id>onlyITs</id>
       <build>
         <plugins>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <excludes>
-                <exclude>**/TheFlintstonesTest.java</exclude>
-                <exclude>**/EntoEndUserCacheLookupEnabledTest.java</exclude>
-                <exclude>**/EntoEndUserCacheLookupDisabledTest.java</exclude>
-                <exclude>**/WindowsAdsiModeUserCacheDisabledTest.java</exclude>
-                <exclude>**/WindowsAdsiModeUserCacheEnabledTest.java</exclude>
-              </excludes>
+              <forkCount>1</forkCount> <!-- using static ports can not be parallized -->
+              <includes>
+                <include>**/*IT.java</include>
+              </includes>
             </configuration>
           </plugin>
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>ITs</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>ITs</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <forkCount>1</forkCount> <!-- using static ports can not be parallized -->
+                  <includes>
+                    <include>**/*IT.java</include>
+                  </includes>
+                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -108,24 +108,10 @@
     </dependency>
     <!-- For docker integration tests -->
     <dependency>
-      <groupId>org.jenkins-ci.test</groupId>
-      <artifactId>docker-fixtures</artifactId>
-      <version>166.v912b_95083ffe</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.17.6</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.inject</groupId>
-          <artifactId>guice</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- JCasC compatibility -->
     <dependency>

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryDomain.java
@@ -207,7 +207,7 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
         Attribute a = null;
         try {
             LOGGER.log(Level.FINE, "Attempting to resolve {0} to NS record", name);
-            ictx = createDNSLookupContext();
+            ictx = DNSUtils.createDNSLookupContext();
             Attributes attributes = ictx.getAttributes(name, new String[]{"NS"});
             a = attributes.get("NS");
             if (a == null) {
@@ -225,15 +225,6 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
         return a;
     }
 
-    /**
-     * Creates {@link DirContext} for accessing DNS.
-     */
-    public DirContext createDNSLookupContext() throws NamingException {
-        Hashtable env = new Hashtable();
-        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
-        env.put("java.naming.provider.url", "dns:");
-        return new InitialDirContext(env);
-    }
 
     /**
      * Get the list of servers which compose the {@link Catalog}
@@ -247,7 +238,7 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
         String ldapServer = catalog + (site != null ? site + "._sites." : "") + this.name;
         LOGGER.log(Level.FINE, "Attempting to resolve {0} to SRV record", ldapServer);
         try {
-            Attributes attributes = createDNSLookupContext().getAttributes(ldapServer, new String[] { "SRV" });
+            Attributes attributes = DNSUtils.createDNSLookupContext().getAttributes(ldapServer, new String[] { "SRV" });
             return attributes.get("SRV");
         } catch (NamingException | NumberFormatException e) {
             LOGGER.log(Level.WARNING, String.format("Failed to resolve %s", ldapServer), e);
@@ -320,7 +311,7 @@ public class ActiveDirectoryDomain extends AbstractDescribableImpl<ActiveDirecto
                 Secret password = Secret.fromString(bindPassword);
 
                 // Then look for the LDAP server
-                DirContext ictx = activeDirectorySecurityRealm.getDescriptor().createDNSLookupContext();
+                DirContext ictx = DNSUtils.createDNSLookupContext();
                 List<SocketInfo> obtainerServers;
                 try {
                     obtainerServers = activeDirectorySecurityRealm.getDescriptor().obtainLDAPServer(ictx, name, site, servers, requireTLS);

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -142,7 +142,7 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     public transient final String site;
 
     /**
-     * Represent the old bindName
+     * Represent the old Name
      *
      * <p>
      * We need to keep this as transient in order to be able to use readResolve
@@ -665,7 +665,6 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                 props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
                 props.put(Context.PROVIDER_URL, ldapUrl);
                 props.put("java.naming.ldap.version", "3");
-                
                 customizeLdapProperties(props);
                 
                 LdapContext context = new InitialLdapContext(props, null);
@@ -729,23 +728,13 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
             }
         }
 
-        /**
-         * Creates {@link DirContext} for accessing DNS.
-         */
-        public DirContext createDNSLookupContext() throws NamingException {
-            Hashtable env = new Hashtable();
-            env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
-            env.put(Context.PROVIDER_URL, "dns:");
-            return new InitialDirContext(env);
-        }
-
         @Deprecated
         public List<SocketInfo> obtainLDAPServer(String domainName, String site, String preferredServer) throws NamingException {
-            return obtainLDAPServer(createDNSLookupContext(), domainName, site, preferredServer);
+            return obtainLDAPServer(DNSUtils.createDNSLookupContext(), domainName, site, preferredServer);
         }
 
         public List<SocketInfo> obtainLDAPServer(ActiveDirectoryDomain activeDirectoryDomain) throws NamingException {
-            return obtainLDAPServer(createDNSLookupContext(), activeDirectoryDomain.getName(), activeDirectoryDomain.getSite(), activeDirectoryDomain.getServers());
+            return obtainLDAPServer(DNSUtils.createDNSLookupContext(), activeDirectoryDomain.getName(), activeDirectoryDomain.getSite(), activeDirectoryDomain.getServers());
         }
 
         /**

--- a/src/main/java/hudson/plugins/active_directory/DNSUtils.java
+++ b/src/main/java/hudson/plugins/active_directory/DNSUtils.java
@@ -1,0 +1,33 @@
+package hudson.plugins.active_directory;
+
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class) // visible for testing.
+public class DNSUtils {
+
+    public static final String OVERRIDE_DNS_PROPERTY = DNSUtils.class.getName() + ".OVERRIDE_DNS_SERVERS";
+
+    /**
+     * Creates {@link DirContext} for accessing DNS. This code allows for easier testing by allowing unit tets to
+     * overide the DNS server, in production this should have no effects.
+     */
+    static DirContext createDNSLookupContext() throws NamingException {
+        Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+        String dns = System.getProperty(OVERRIDE_DNS_PROPERTY);
+        if (dns != null) {
+            env.put("java.naming.provider.url", dns);
+            System.out.println("Overriding DNS to: " + dns);
+        } else {
+            env.put("java.naming.provider.url", "dns:");
+        }
+        return new InitialDirContext(env);
+    }
+
+}

--- a/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheDisabledIT.java
+++ b/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheDisabledIT.java
@@ -1,7 +1,6 @@
 package hudson.plugins.active_directory;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,8 +17,12 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-
-public class WindowsAdsiModeUserCacheEnabledTest {
+/**
+ * This tests requires a very specific windows environment to run, the windows machine
+ * needs to be joined to a function domain that has the user fred with the password ia4uV1EeKait.
+ * It is enabled in the ITs profile, but will skip on I as that profile is enabled only on the special Linux environment.
+ */
+public class WindowsAdsiModeUserCacheDisabledIT {
 
     @BeforeClass
     public static void setUp() {
@@ -31,24 +34,6 @@ public class WindowsAdsiModeUserCacheEnabledTest {
 
     @Rule
     public LoggerRule l = new LoggerRule();
-
-    private static String CACHE_AUTH;
-
-    @BeforeClass
-    public static void enableHealthMetrics() {
-        CACHE_AUTH = System.getProperty(CacheUtil.class.getName() + ".cacheAuth");
-        System.setProperty(CacheUtil.class.getName() + ".cacheAuth", "true");
-    }
-
-    @AfterClass
-    public static void disableHealthMetrics() {
-        // Put back the previous value before the test was executed
-        if (CACHE_AUTH != null) {
-            System.setProperty(CacheUtil.class.getName() + ".cacheAuth", CACHE_AUTH);
-        } else {
-            System.clearProperty(CacheUtil.class.getName() + ".cacheAuth");
-        }
-    }
 
     public void dynamicCacheEnableSetUp() throws Exception {
         CacheConfiguration cacheConfiguration = new CacheConfiguration(500,30);

--- a/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheEnabledIT.java
+++ b/src/test/java/hudson/plugins/active_directory/WindowsAdsiModeUserCacheEnabledIT.java
@@ -1,6 +1,7 @@
 package hudson.plugins.active_directory;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,7 +19,12 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 
-public class WindowsAdsiModeUserCacheDisabledTest {
+/**
+ * This tests requires a very specific windows environment to run, the windows machine
+ * needs to be joined to a function domain that has the user fred with the password ia4uV1EeKait.
+ * It is enabled in the ITs profile, but will skip on I as that profile is enabled only on the special Linux environment.
+ */
+public class WindowsAdsiModeUserCacheEnabledIT {
 
     @BeforeClass
     public static void setUp() {
@@ -30,6 +36,24 @@ public class WindowsAdsiModeUserCacheDisabledTest {
 
     @Rule
     public LoggerRule l = new LoggerRule();
+
+    private static String CACHE_AUTH;
+
+    @BeforeClass
+    public static void enableHealthMetrics() {
+        CACHE_AUTH = System.getProperty(CacheUtil.class.getName() + ".cacheAuth");
+        System.setProperty(CacheUtil.class.getName() + ".cacheAuth", "true");
+    }
+
+    @AfterClass
+    public static void disableHealthMetrics() {
+        // Put back the previous value before the test was executed
+        if (CACHE_AUTH != null) {
+            System.setProperty(CacheUtil.class.getName() + ".cacheAuth", CACHE_AUTH);
+        } else {
+            System.clearProperty(CacheUtil.class.getName() + ".cacheAuth");
+        }
+    }
 
     public void dynamicCacheEnableSetUp() throws Exception {
         CacheConfiguration cacheConfiguration = new CacheConfiguration(500,30);

--- a/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
@@ -1,13 +1,22 @@
 package hudson.plugins.active_directory.docker;
 
+import java.io.IOException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.InternetProtocol;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+import com.github.dockerjava.api.model.Ports.Binding;
 
 public class ActiveDirectoryGenericContainer<SELF extends ActiveDirectoryGenericContainer<SELF>> extends GenericContainer<SELF> {
 
     public ActiveDirectoryGenericContainer() {
-        setImage(new ImageFromDockerfile("ad-dc", false)
+        super(new ImageFromDockerfile("ad-dc", false)
                 .withFileFromClasspath("custom.sh", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh")
                 .withFileFromClasspath("Dockerfile", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/Dockerfile")
                 .withFileFromClasspath("init.sh", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/init.sh")
@@ -17,13 +26,63 @@ public class ActiveDirectoryGenericContainer<SELF extends ActiveDirectoryGeneric
                 .withFileFromClasspath("sssd.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/sssd.conf")
                 .withFileFromClasspath("supervisord.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/supervisord.conf"));
         setWaitStrategy(null);
-        addFixedExposedPort(135, 135);
-        addFixedExposedPort(138, 138);
-        addFixedExposedPort(445, 445);
-        addFixedExposedPort(39, 39);
-        addFixedExposedPort(464, 464);
-        addFixedExposedPort(389, 389);
-        addFixedExposedPort(3268, 3268);
-        addFixedExposedPort(53, 53, InternetProtocol.UDP);
+    }
+
+    /*
+     * Expose ports needed for tests statically.
+     * Any tests using this can NOT be run in parallel and require some special infra setup (overriding the hosts DNS server) so must be in a file named {@code *IT.java}.
+     */
+    public ActiveDirectoryGenericContainer<SELF> withStaticPorts() {
+        addFixedExposedPort(3268, 3268); // global catalog
+        addFixedExposedPort(53, 53, InternetProtocol.TCP); // DNS over TCP
+        addFixedExposedPort(53, 53, InternetProtocol.UDP); // DNS over UDP
+        return this;
+    }
+
+    /** Expose container ports via mapped ports */
+    public ActiveDirectoryGenericContainer<SELF> withDynamicPorts() {
+        // we only need the global catalog for the tests.
+        // we do not need to expose the CIFS ports (135,138,464)
+        // tests using DNS can use to perform DNS lookup, however subsequent connection to the servvices would be via the SRV record and that requires 
+        // the ports to match..
+        addExposedPort(3268); // global catalog
+
+        // https://github.com/testcontainers/testcontainers-java/issues/554
+        // addExposedPort(53, InternetProtocol.UDP);
+        return this.withCreateContainerCmdModifier(t -> addExposedUDP(t, 53));
+    }
+
+    private CreateContainerCmd addExposedUDP(CreateContainerCmd t, int port) {
+        HostConfig hostConfig = t.getHostConfig();
+        Ports portBindings = hostConfig.getPortBindings();
+        portBindings.add(new PortBinding(Binding.empty(), ExposedPort.udp(port)));
+        return t;
+    }
+
+    /**
+     * Obtain the port for the UDP DNS server.
+     * This method will only work if using withDynamicPorts
+     */
+    public String getDNSPort() throws InterruptedException, IOException {
+        // NetworkSettings networkSettings = getContainerInfo().getNetworkSettings();
+        // whilst the above should work it is returning something that is not matching reality and does not contain the actual ports!
+        // this happens even one subsequent calls (appears as though the response is cached)
+
+        // resort to the API.
+        do {
+            @SuppressWarnings("resource") // the docker client is global
+            DockerClient dockerClient = getDockerClient();
+            try (InspectContainerCmd inspectContainerCmd = dockerClient.inspectContainerCmd(getContainerId())) {
+                Binding[] bindings = inspectContainerCmd.exec().getNetworkSettings().getPorts().getBindings().get(ExposedPort.udp(53));
+                if (bindings != null) {
+                    return bindings[0].getHostPortSpec();
+                }
+            }
+            // unclear why docker is returning a reponse that everything is started without all the port bindings but 
+            // this was the case on windows with docker desktop 4.13.0 
+            System.err.println("docker response did not contain the port map for DNS. Sleeping before retrying...");
+            Thread.sleep(1_000L);
+        } while (true);
+
     }
 }

--- a/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
@@ -16,6 +16,7 @@ public class ActiveDirectoryGenericContainer<SELF extends ActiveDirectoryGeneric
                 .withFileFromClasspath("named.conf.options", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/named.conf.options")
                 .withFileFromClasspath("sssd.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/sssd.conf")
                 .withFileFromClasspath("supervisord.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/supervisord.conf"));
+        setWaitStrategy(null);
         addFixedExposedPort(135, 135);
         addFixedExposedPort(138, 138);
         addFixedExposedPort(445, 445);

--- a/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
@@ -1,0 +1,28 @@
+package hudson.plugins.active_directory.docker;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.InternetProtocol;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+public class ActiveDirectoryGenericContainer<SELF extends ActiveDirectoryGenericContainer<SELF>> extends GenericContainer<SELF> {
+
+    public ActiveDirectoryGenericContainer() {
+        setImage(new ImageFromDockerfile("ad-dc", false)
+                .withFileFromClasspath("custom.sh", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh")
+                .withFileFromClasspath("Dockerfile", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/Dockerfile")
+                .withFileFromClasspath("init.sh", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/init.sh")
+                .withFileFromClasspath("kdb5_util_create.expect", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/kdb5_util_create.expect")
+                .withFileFromClasspath("krb5.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/krb5.conf")
+                .withFileFromClasspath("named.conf.options", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/named.conf.options")
+                .withFileFromClasspath("sssd.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/sssd.conf")
+                .withFileFromClasspath("supervisord.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/supervisord.conf"));
+        addFixedExposedPort(135, 135);
+        addFixedExposedPort(138, 138);
+        addFixedExposedPort(445, 445);
+        addFixedExposedPort(39, 39);
+        addFixedExposedPort(464, 464);
+        addFixedExposedPort(389, 389);
+        addFixedExposedPort(3268, 3268);
+        addFixedExposedPort(53, 53, InternetProtocol.UDP);
+    }
+}

--- a/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupDisabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupDisabledTest.java
@@ -8,10 +8,13 @@ import hudson.plugins.active_directory.CacheConfiguration;
 import hudson.plugins.active_directory.GroupLookupStrategy;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.userdetails.UserDetails;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
 import java.util.ArrayList;
@@ -25,8 +28,13 @@ import static org.junit.Assert.fail;
 
 public class EntoEndUserCacheLookupDisabledTest {
 
+    @Before
+    public void skipIfNoDocker() {
+        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
+    }
+
     @Rule
-    public GenericContainer docker = new ActiveDirectoryGenericContainer();
+    public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withDynamicPorts();
 
     @Rule
     public JenkinsRule j = new JenkinsRule();

--- a/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupDisabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupDisabledTest.java
@@ -28,15 +28,13 @@ import static org.junit.Assert.fail;
 
 public class EntoEndUserCacheLookupDisabledTest {
 
-    @Before
-    public void skipIfNoDocker() {
-        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
-    }
+    @Rule(order = 0)
+    public RequireDockerRule rdr = new RequireDockerRule();
 
-    @Rule
+    @Rule(order = 1)
     public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withDynamicPorts();
 
-    @Rule
+    @Rule(order = 2) // start Jenkins after the container so that timeouts do not apply to container building.
     public JenkinsRule j = new JenkinsRule();
 
     @Rule

--- a/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
@@ -10,11 +10,14 @@ import hudson.plugins.active_directory.GroupLookupStrategy;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.userdetails.UserDetails;
 import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
 import java.util.ArrayList;
@@ -28,8 +31,13 @@ import static org.junit.Assert.fail;
 
 public class EntoEndUserCacheLookupEnabledTest {
 
+    @Before
+    public void skipIfNoDocker() {
+        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
+    }
+
     @Rule
-    public GenericContainer docker = new ActiveDirectoryGenericContainer();
+    public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withDynamicPorts();
 
     @Rule
     public JenkinsRule j = new JenkinsRule();

--- a/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
@@ -9,16 +9,13 @@ import hudson.plugins.active_directory.CacheUtil;
 import hudson.plugins.active_directory.GroupLookupStrategy;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.userdetails.UserDetails;
-import org.apache.commons.io.FileUtils;
-import org.jenkinsci.test.acceptance.docker.DockerContainer;
-import org.jenkinsci.test.acceptance.docker.DockerFixture;
-import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
+import org.testcontainers.containers.GenericContainer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +29,7 @@ import static org.junit.Assert.fail;
 public class EntoEndUserCacheLookupEnabledTest {
 
     @Rule
-    public DockerRule<TheFlintstonesTest.TheFlintstones> docker = new DockerRule<>(TheFlintstonesTest.TheFlintstones.class);
+    public GenericContainer docker = new ActiveDirectoryGenericContainer();
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -68,9 +65,8 @@ public class EntoEndUserCacheLookupEnabledTest {
     public void customSingleADSetup(ActiveDirectoryDomain activeDirectoryDomain, String site, String bindName, String bindPassword,
                                     GroupLookupStrategy groupLookupStrategy, boolean removeIrrelevantGroups, Boolean customDomain,
                                     CacheConfiguration cache, Boolean startTls, ActiveDirectoryInternalUsersDatabase internalUsersDatabase) throws Exception {
-        TheFlintstonesTest.TheFlintstones d = docker.get();
-        dockerIp = d.ipBound(3268);
-        dockerPort = d.port(3268);
+        dockerIp = docker.getHost();
+        dockerPort = docker.getMappedPort(3268);
 
         activeDirectoryDomain.servers = dockerIp + ":" + dockerPort;
         List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
@@ -78,7 +74,7 @@ public class EntoEndUserCacheLookupEnabledTest {
 
         ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, site, bindName, bindPassword, null, groupLookupStrategy, removeIrrelevantGroups, customDomain, cache, startTls, internalUsersDatabase, false);
         j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
-        while(!FileUtils.readFileToString(d.getLogfile()).contains("custom (exit status 0; expected)")) {
+        while(!docker.getLogs().contains("custom (exit status 0; expected)")) {
             Thread.sleep(1000);
         }
         UserDetails userDetails = null;
@@ -161,10 +157,5 @@ public class EntoEndUserCacheLookupEnabledTest {
         // Try to login as Fred with correct password
         wc.login("Fred", "ia4uV1EeKait");
         assertThat(wc.goToXml("whoAmI/api/xml").asXml().replaceAll("\\s+", ""), containsString("<name>Fred</name>"));
-    }
-
-    @DockerFixture(id = "ad-dc", ports= {135, 138, 445, 39, 464, 389, 3268}, udpPorts = {53}, matchHostPorts = true, dockerfileFolder="docker/TheFlintstonesTest/TheFlintstones")
-    public static class TheFlintstones extends DockerContainer {
-
     }
 }

--- a/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/EntoEndUserCacheLookupEnabledTest.java
@@ -31,15 +31,13 @@ import static org.junit.Assert.fail;
 
 public class EntoEndUserCacheLookupEnabledTest {
 
-    @Before
-    public void skipIfNoDocker() {
-        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
-    }
+    @Rule(order = 0)
+    public RequireDockerRule rdr = new RequireDockerRule();
 
-    @Rule
+    @Rule(order = 1)
     public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withDynamicPorts();
 
-    @Rule
+    @Rule(order = 2) // start Jenkins after the container so that timeouts do not apply to container building.
     public JenkinsRule j = new JenkinsRule();
 
     @Rule

--- a/src/test/java/hudson/plugins/active_directory/docker/RequireDockerRule.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/RequireDockerRule.java
@@ -1,0 +1,38 @@
+package hudson.plugins.active_directory.docker;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.testcontainers.DockerClientFactory;
+
+/**
+ * Junit 4 {@code Rule} that will skip the test if the docker client is not available.
+ * This rule must have a lower {@link Rule#order} specified that any other {@code Rule} that 
+ * uses docker in order to skip tests, otherwise the other rules would fail first causing build failures.
+ * e.g. <pre><code>
+    {@literal @}Rule(order = -10)
+    public RequireDockerRule rdr = new RequireDockerRule();
+ }
+ * </code></pre>
+ */
+public class RequireDockerRule implements TestRule {
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        if (DockerClientFactory.instance().isDockerAvailable()) {
+            return base;
+        }
+        return new DockerNotAvailbleStatement();
+    }
+
+    private static class DockerNotAvailbleStatement extends  Statement {
+
+        @Override
+        public void evaluate() throws Throwable {
+            throw new AssumptionViolatedException("Docker is not available and this test requires docker");
+        }
+    }
+
+}

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesIT.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesIT.java
@@ -50,15 +50,13 @@ import hudson.util.Secret;
  */
 public class TheFlintstonesIT {
 
-    @Before
-    public void skipIfNoDocker() {
-        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
-    }
+    @Rule(order = 0)
+    public RequireDockerRule rdr = new RequireDockerRule();
 
-    @Rule
+    @Rule(order = 1)
     public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withStaticPorts();
 
-    @Rule
+    @Rule(order = 2) // start Jenkins after the container so that timeouts do not apply to container building.
     public JenkinsRule j = new JenkinsRule();
 
     @Rule

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesIT.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesIT.java
@@ -94,31 +94,6 @@ public class TheFlintstonesIT {
         }
     }
 
-    public void manualSetUp() throws Exception {
-        dockerIp = docker.getHost();
-        dockerPort = docker.getMappedPort(3268);
-
-        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) j.jenkins.getSecurityRealm();
-        for (ActiveDirectoryDomain activeDirectoryDomain : activeDirectorySecurityRealm.getDomains()) {
-            activeDirectoryDomain.bindPassword = Secret.fromString(AD_MANAGER_DN_PASSWORD);
-            activeDirectoryDomain.servers = dockerIp + ":" +  dockerPort;
-        }
-
-        while(!docker.getLogs().contains("custom (exit status 0; expected)")) {
-            Thread.sleep(1000);
-        }
-        UserDetails userDetails = null;
-        int i = 0;
-        while (i < MAX_RETRIES && userDetails == null) {
-            try {
-                userDetails = j.jenkins.getSecurityRealm().loadUserByUsername("Fred");
-            } catch (AuthenticationServiceException e) {
-                Thread.sleep(1000);
-            }
-            i ++;
-        }
-    }
-
     @Issue("JENKINS-36148")
     @Test
     public void validateCustomDomainController() throws ServletException, NamingException, IOException, Exception {

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesIT.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesIT.java
@@ -1,0 +1,155 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, Felix Belzunce Arcos, CloudBees, Inc., and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.plugins.active_directory.docker;
+
+import static org.junit.Assert.assertEquals;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import org.acegisecurity.AuthenticationServiceException;
+import org.acegisecurity.userdetails.UserDetails;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.testcontainers.DockerClientFactory;
+import hudson.plugins.active_directory.ActiveDirectoryDomain;
+import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
+import hudson.plugins.active_directory.GroupLookupStrategy;
+import hudson.util.Secret;
+
+/**
+ * Integration tests with Docker and requiring custom DNS in the target env with fixed ports.
+ */
+public class TheFlintstonesIT {
+
+    @Before
+    public void skipIfNoDocker() {
+        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
+    }
+
+    @Rule
+    public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withStaticPorts();
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public LoggerRule l = new LoggerRule();
+
+    public final static String AD_DOMAIN = "samdom.example.com";
+    public final static String AD_MANAGER_DN = "CN=Administrator,CN=Users,DC=SAMDOM,DC=EXAMPLE,DC=COM";
+    public final static String AD_MANAGER_DN_PASSWORD = "ia4uV1EeKait";
+    public final static int MAX_RETRIES = 30;
+    public String dockerIp;
+    public int dockerPort;
+
+    public void dynamicSetUp() throws Exception {
+        dockerIp = docker.getHost();
+        dockerPort = docker.getMappedPort(3268);
+        ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain(AD_DOMAIN, dockerIp + ":" +  dockerPort , null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD);
+        List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
+        domains.add(activeDirectoryDomain);
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null, null, GroupLookupStrategy.RECURSIVE, false, true, null, false, null, false);
+        j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
+        while(!docker.getLogs().contains("custom (exit status 0; expected)")) {
+            Thread.sleep(1000);
+        }
+        UserDetails userDetails = null;
+        int i = 0;
+        while (i < MAX_RETRIES && userDetails == null) {
+            try {
+                userDetails = j.jenkins.getSecurityRealm().loadUserByUsername("Fred");
+            } catch (AuthenticationServiceException e) {
+                Thread.sleep(1000);
+            }
+            i ++;
+        }
+    }
+
+    public void manualSetUp() throws Exception {
+        dockerIp = docker.getHost();
+        dockerPort = docker.getMappedPort(3268);
+
+        ActiveDirectorySecurityRealm activeDirectorySecurityRealm = (ActiveDirectorySecurityRealm) j.jenkins.getSecurityRealm();
+        for (ActiveDirectoryDomain activeDirectoryDomain : activeDirectorySecurityRealm.getDomains()) {
+            activeDirectoryDomain.bindPassword = Secret.fromString(AD_MANAGER_DN_PASSWORD);
+            activeDirectoryDomain.servers = dockerIp + ":" +  dockerPort;
+        }
+
+        while(!docker.getLogs().contains("custom (exit status 0; expected)")) {
+            Thread.sleep(1000);
+        }
+        UserDetails userDetails = null;
+        int i = 0;
+        while (i < MAX_RETRIES && userDetails == null) {
+            try {
+                userDetails = j.jenkins.getSecurityRealm().loadUserByUsername("Fred");
+            } catch (AuthenticationServiceException e) {
+                Thread.sleep(1000);
+            }
+            i ++;
+        }
+    }
+
+    @Issue("JENKINS-36148")
+    @Test
+    public void validateCustomDomainController() throws ServletException, NamingException, IOException, Exception {
+        dynamicSetUp();
+        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
+        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, dockerIp + ":" + dockerPort, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
+    }
+
+    @Issue("JENKINS-36148")
+    @Test
+    public void validateDomain() throws ServletException, NamingException, IOException, Exception {
+        dynamicSetUp();
+        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
+        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, null, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
+
+    }
+
+    @Issue("JENKINS-69683")
+    @Test
+    public void validateTestDomainRequireTLSDisabled() throws Exception {
+        dynamicSetUp();
+        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
+        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, null, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
+    }
+
+    @Issue("JENKINS-69683")
+    @Test
+    public void validateTestDomainServerRequireTLSDisabled() throws Exception {
+        dynamicSetUp();
+        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
+        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, dockerIp + ":" +  dockerPort, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
+    }
+
+}

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -27,31 +27,33 @@ package hudson.plugins.active_directory.docker;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import hudson.plugins.active_directory.ActiveDirectoryDomain;
 import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
+import hudson.plugins.active_directory.DNSUtils;
 import hudson.plugins.active_directory.GroupLookupStrategy;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
-
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.DockerClientFactory;
 
 import javax.naming.CommunicationException;
-import javax.naming.NamingException;
-import javax.servlet.ServletException;
-import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -72,8 +74,13 @@ import org.jvnet.hudson.test.recipes.LocalData;
  */
 public class TheFlintstonesTest {
 
+    @Before
+    public void skipIfNoDocker() {
+        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
+    }
+
     @Rule
-    public GenericContainer docker = new ActiveDirectoryGenericContainer();
+    public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withDynamicPorts();
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -87,6 +94,21 @@ public class TheFlintstonesTest {
     public final static int MAX_RETRIES = 30;
     public String dockerIp;
     public int dockerPort;
+
+    @Before
+    public void overrideDNS() throws Exception {
+        // see hudson.plugins.active_directory.ActiveDirectoryDomain.createDNSLookupContext()
+        // getHost returns a hostname not IPaddress...
+        // use our DNS to resolve that to an IP address.
+        String DNS_URLs = "dns://"+InetAddress.getByName(docker.getHost()).getHostAddress()+":"+docker.getDNSPort();
+        System.setProperty(DNSUtils.OVERRIDE_DNS_PROPERTY, DNS_URLs);
+    }
+
+    @After
+    public void resetDNS() {
+        // see hudson.plugins.active_directory.ActiveDirectoryDomain.createDNSLookupContext()
+        System.clearProperty(ActiveDirectoryDomain.class.getName()+ ".OVERRIDE_DNS_SERVERS");
+    }
 
     public void dynamicSetUp() throws Exception {
         dockerIp = docker.getHost();
@@ -177,32 +199,6 @@ public class TheFlintstonesTest {
         } catch (UsernameNotFoundException e) {
             assertTrue(e.getMessage().contains("Authentication was successful but cannot locate the user information for Homer"));
         }
-    }
-
-    @Issue("JENKINS-36148")
-    @Test
-    public void checkDomainHealth() throws Exception {
-        dynamicSetUp();
-        ActiveDirectorySecurityRealm securityRealm = (ActiveDirectorySecurityRealm) Jenkins.getInstance().getSecurityRealm();
-        ActiveDirectoryDomain domain = securityRealm.getDomain(AD_DOMAIN);
-        assertEquals("NS: dc1.samdom.example.com.", domain.getRecordFromDomain().toString().trim());
-    }
-
-    @Issue("JENKINS-36148")
-    @Test
-    public void validateCustomDomainController() throws ServletException, NamingException, IOException, Exception {
-        dynamicSetUp();
-        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
-        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, dockerIp + ":" + dockerPort, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
-    }
-
-    @Issue("JENKINS-36148")
-    @Test
-    public void validateDomain() throws ServletException, NamingException, IOException, Exception {
-        dynamicSetUp();
-        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
-        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, null, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
-
     }
 
     @Issue("JENKINS-45576")
@@ -344,20 +340,13 @@ public class TheFlintstonesTest {
         assertTrue(messages.stream().anyMatch(s -> s.contains("Failed to retrieve user Fred")));
     }
 
-    @Issue("JENKINS-69683")
+    @Issue("JENKINS-36148")
     @Test
-    public void validateTestDomainRequireTLSDisabled() throws Exception {
+    public void checkDomainHealth() throws Exception {
         dynamicSetUp();
-        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
-        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, null, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
+        ActiveDirectorySecurityRealm securityRealm = (ActiveDirectorySecurityRealm) Jenkins.getInstance().getSecurityRealm();
+        ActiveDirectoryDomain domain = securityRealm.getDomain(AD_DOMAIN);
+        assertEquals("NS: dc1.samdom.example.com.", domain.getRecordFromDomain().toString().trim());
     }
 
-
-    @Issue("JENKINS-69683")
-    @Test
-    public void validateTestDomainServerRequireTLSDisabled() throws Exception {
-        dynamicSetUp();
-        ActiveDirectoryDomain.DescriptorImpl adDescriptor = new ActiveDirectoryDomain.DescriptorImpl();
-        assertEquals("OK: Success", adDescriptor.doValidateTest(AD_DOMAIN, dockerIp + ":" +  dockerPort, null, AD_MANAGER_DN, AD_MANAGER_DN_PASSWORD, null, false).toString().trim());
-    }
 }

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -74,15 +74,13 @@ import org.jvnet.hudson.test.recipes.LocalData;
  */
 public class TheFlintstonesTest {
 
-    @Before
-    public void skipIfNoDocker() {
-        Assume.assumeTrue("Docker is needed to run these tests", DockerClientFactory.instance().isDockerAvailable());
-    }
+    @Rule(order = 0)
+    public RequireDockerRule rdr = new RequireDockerRule();
 
-    @Rule
+    @Rule(order = 1)
     public ActiveDirectoryGenericContainer<?> docker = new ActiveDirectoryGenericContainer<>().withDynamicPorts();
 
-    @Rule
+    @Rule(order = 2) // start Jenkins after the container so that timeouts do not apply to container building.
     public JenkinsRule j = new JenkinsRule();
 
     @Rule

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/Dockerfile
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/Dockerfile
@@ -51,6 +51,6 @@ RUN chmod +x /usr/local/bin/custom.sh
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD init.sh /init.sh
 RUN chmod 755 /init.sh
-EXPOSE 22 53 389 88 135 139 138 445 464 3268 3269
+EXPOSE 22 53/udp 53/tcp 389 88 135 139 138 445 464 3268 3269
 ENTRYPOINT ["/init.sh"]
 CMD ["app:start"]


### PR DESCRIPTION
#148 revealed to me that all the containerized tests where using fixed ports.

Not only does that mean we can not run tests in parallel, it also meant that the docker tests would not work on windows as you can not bind to the CIFS ports (reserved for windows only).

The tests infact did not need these ports All bar 4 tests in the `FlinstonesTests` did not need the full e2e environment.

This moves the ports to be dynamic for most of the tests, leaving just tests split out of the FlintStones tests that need some fixed ports in a new class.
Additionally the *very special* Windows require a custom env so these and the split tests are in a IT profile.

Adapted the IT profile so that you can always run with `forkCount > 1` without any random tests as the ITs are run either on their own without the other tests and hardCode the `forkCount` or they are run in separate surefire configuration that again uses a hardcoded `forkCount`

The tests using docker that are no longer in the profile have a new assumption for the availabliltiy of Docker.
The production code was improved to be able to override the DNS setting for jndi (and only jndi) to enable a few tests to work outside of the special environment.

Please do not merge this until #148 is merged.

`TestContainers` is sadly lacking in several areas as you can see in the code :-(

easiest way to review the diff from #148 is to look at the [single commit](https://github.com/jenkinsci/active-directory-plugin/pull/153/commits/b1394a3468695e2aa9310dc78e48888727fc9677)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
