### PR TITLE
Revert "Forward compatibility with jenkins-buttons"

### DIFF
--- a/src/main/resources/hudson/plugins/active_directory/Security1389AdministrativeMonitor/message.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/Security1389AdministrativeMonitor/message.jelly
@@ -3,7 +3,7 @@
 
   <div class="alert alert-danger">
     <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit primary="false" clazz="jenkins-!-destructive-color" value="${%Dismiss}"/>
+      <f:submit value="${%Dismiss}"/>
     </form>
     <p>${%blurb(rootURL + "/configureSecurity/")}</p>
   </div>

--- a/src/main/resources/hudson/plugins/active_directory/Security1389AdministrativeMonitorLegacySysProp/message.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/Security1389AdministrativeMonitorLegacySysProp/message.jelly
@@ -3,7 +3,7 @@
 
   <div class="alert alert-warning">
     <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit primary="false" clazz="jenkins-!-destructive-color" value="${%Dismiss}"/>
+      <f:submit value="${%Dismiss}" />
     </form>
     <p>${%blurb}</p>
   </div>


### PR DESCRIPTION
Reverts jenkinsci/active-directory-plugin#140 because we're reverting the core PR.