### PR TITLE
[JENKINS-70270] Only trigger SecurityListener on real authentication username/password

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryAuthenticationProvider.java
@@ -43,7 +43,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.security.GroupDetails;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException;
-import jenkins.security.SecurityListener;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.GrantedAuthority;
@@ -253,15 +252,13 @@ public class ActiveDirectoryAuthenticationProvider extends AbstractActiveDirecto
 
                         LOGGER.log(Level.FINE, "Login successful: {0} dn={1}", new Object[] {username, dn});
 
-                        UserDetails userDetails = new ActiveDirectoryUserDetail(
+                        return new ActiveDirectoryUserDetail(
                             username, "redacted",
                             !isAccountDisabled(usr),
                             true, true, true,
                             groups.toArray(new GrantedAuthority[0]),
                             getFullName(usr), getEmailAddress(usr), getTelephoneNumber(usr)
                         ).updateUserInfo();
-                        SecurityListener.fireAuthenticated(userDetails);
-                        return userDetails;
                     } finally {
                         col.disposeAll();
                         COM4J.removeListener(col);

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -39,6 +39,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
+import jenkins.security.SecurityListener;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
@@ -891,7 +892,9 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
 
     @Override
     protected UserDetails authenticate(String username, String password) throws AuthenticationException {
-        return getAuthenticationProvider().retrieveUser(username,new UsernamePasswordAuthenticationToken(username,password));
+        UserDetails userDetails = getAuthenticationProvider().retrieveUser(username,new UsernamePasswordAuthenticationToken(username,password));
+        SecurityListener.fireAuthenticated(userDetails);
+        return userDetails;
     }
 
     private static final Logger LOGGER = Logger.getLogger(ActiveDirectorySecurityRealm.class.getName());

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -37,7 +37,6 @@ import hudson.util.Secret;
 
 import javax.naming.NameNotFoundException;
 
-import jenkins.security.SecurityListener;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.AuthenticationServiceException;
 import org.acegisecurity.BadCredentialsException;
@@ -221,9 +220,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
 
             for (ActiveDirectoryDomain domain : domains) {
                 try {
-                    UserDetails userDetails = retrieveUser(username, authentication, domain);
-                    SecurityListener.fireAuthenticated(userDetails);
-                    return userDetails;
+                    return retrieveUser(username, authentication, domain);
                 } catch (NamingException ne) {
                     if (userMatchesInternalDatabaseUser(username)) {
                         LOGGER.log(Level.WARNING, String.format("Looking into Jenkins Internal Users Database for user %s", username));
@@ -235,9 +232,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                         }
                         if (hudsonPrivateSecurityRealm.isPasswordCorrect(password)) {
                             LOGGER.log(Level.INFO, String.format("Falling back into the internal user %s", username));
-                            UserDetails userDetails = new ActiveDirectoryUserDetail(username, "redacted", true, true, true, true, hudsonPrivateSecurityRealm.getAuthorities(), internalUser.getDisplayName(), "", "");
-                            SecurityListener.fireAuthenticated(userDetails);
-                            return userDetails;
+                            return new ActiveDirectoryUserDetail(username, "redacted", true, true, true, true, hudsonPrivateSecurityRealm.getAuthorities(), internalUser.getDisplayName(), "", "");
                         } else {
                             LOGGER.log(Level.WARNING, String.format("Credential exception trying to authenticate against %s domain", domain.getName()), ne);
                             errors.add(new MultiCauseUserMayOrMayNotExistException("We can't tell if the user exists or not: " + username, notFound));


### PR DESCRIPTION


<!-- Please describe your pull request here. -->
This PR intends to address [JENKINS-70270](https://issues.jenkins.io/browse/JENKINS-70270) by locating the SecurityListener at the highest level avoiding being triggered on internal lookup events which are not related to the real authentication, and which were producing `StackOverflowError`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
