### PR TITLE
Adapt TheFlintstonesTest to IPv6 testing environments

### DIFF
--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -98,7 +98,11 @@ public class TheFlintstonesTest {
         // see hudson.plugins.active_directory.ActiveDirectoryDomain.createDNSLookupContext()
         // getHost returns a hostname not IPaddress...
         // use our DNS to resolve that to an IP address.
-        String DNS_URLs = "dns://"+InetAddress.getByName(docker.getHost()).getHostAddress()+":"+docker.getDNSPort();
+        String hostAddress = InetAddress.getByName(docker.getHost()).getHostAddress();
+        if (Boolean.getBoolean("java.net.preferIPv6Addresses")) {
+            hostAddress = String.format("[%s]", hostAddress);
+        } 
+        String DNS_URLs = "dns://"+hostAddress+":"+docker.getDNSPort();
         System.setProperty(DNSUtils.OVERRIDE_DNS_PROPERTY, DNS_URLs);
     }
 

--- a/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/TheFlintstonesTest.java
@@ -46,6 +46,7 @@ import org.testcontainers.DockerClientFactory;
 import javax.naming.CommunicationException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -98,11 +99,7 @@ public class TheFlintstonesTest {
         // see hudson.plugins.active_directory.ActiveDirectoryDomain.createDNSLookupContext()
         // getHost returns a hostname not IPaddress...
         // use our DNS to resolve that to an IP address.
-        String hostAddress = InetAddress.getByName(docker.getHost()).getHostAddress();
-        if (Boolean.getBoolean("java.net.preferIPv6Addresses")) {
-            hostAddress = String.format("[%s]", hostAddress);
-        } 
-        String DNS_URLs = "dns://"+hostAddress+":"+docker.getDNSPort();
+        String DNS_URLs = new URI("dns", null, InetAddress.getByName(docker.getHost()).getHostAddress(), Integer.parseInt(docker.getDNSPort()), null, null, null).toASCIIString();
         System.setProperty(DNSUtils.OVERRIDE_DNS_PROPERTY, DNS_URLs);
     }
 


### PR DESCRIPTION
### Highlights
- This PR adapts the execution of `TheFlintstonesTest` for IPv6 testing environments
- It makes feasible to use the overrided DNS as `dns://[0:0:0:0:0:0:0:1]:32780`

### Testing done
- Tested via PCT under IPv4 and IPv6 environments and working as expected.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
