### PR TITLE
Bump `git-changelist-maven-extension` to 1.8

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.7</version>
+    <version>1.8</version>
   </extension>
 </extensions>


### PR DESCRIPTION
For unknown reasons, @dependabot is not offering this. Trunk builds broken trying to accessing 1.7, also for unknown reasons.