### PR TITLE
[JENKINS-73827] Adding a login password length check on ActiveDirectorySecurityRealm.…

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -61,6 +61,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.verb.GET;
 import org.kohsuke.stapler.verb.POST;
 import org.springframework.dao.DataAccessException;
+import org.springframework.security.authentication.AuthenticationServiceException;
 
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -945,7 +946,8 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
     protected UserDetails authenticate(String username, String password) throws AuthenticationException {
         // Check if the password length is less than 14 characters
         if(FIPS140.useCompliantAlgorithms() && StringUtils.length(password) < 14) {
-            throw new IllegalArgumentException(Messages.passwordTooShortFIPS());
+            LOGGER.log(Level.SEVERE, String.format(Messages.passwordTooShortFIPS()));
+            throw new AuthenticationServiceException(Messages.passwordTooShortFIPS());
         }
         UserDetails userDetails = getAuthenticationProvider().retrieveUser(username,new UsernamePasswordAuthenticationToken(username,password));
         SecurityListener.fireAuthenticated(userDetails);

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -24,6 +24,7 @@
 package hudson.plugins.active_directory;
 
 import com4j.typelibs.ado20.ClassFactory;
+import io.jenkins.cli.shaded.org.apache.commons.lang.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -941,6 +942,10 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
 
     @Override
     protected UserDetails authenticate(String username, String password) throws AuthenticationException {
+        // Check if the password length is less than 14 characters
+        if(FIPS140.useCompliantAlgorithms() && StringUtils.length(password) < 14) {
+            throw new IllegalArgumentException(Messages.passwordTooShortFIPS());
+        }
         UserDetails userDetails = getAuthenticationProvider().retrieveUser(username,new UsernamePasswordAuthenticationToken(username,password));
         SecurityListener.fireAuthenticated(userDetails);
         return userDetails;

--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -24,7 +24,7 @@
 package hudson.plugins.active_directory;
 
 import com4j.typelibs.ado20.ClassFactory;
-import io.jenkins.cli.shaded.org.apache.commons.lang.StringUtils;
+
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -49,6 +49,7 @@ import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/resources/hudson/plugins/active_directory/Messages.properties
+++ b/src/main/resources/hudson/plugins/active_directory/Messages.properties
@@ -14,3 +14,5 @@ TlsConfiguration.JdkTrustStore = JDK TrustStore
 
 TlsConfiguration.AdministrativeMonitor.DisplayName = Active Directory TLS Configuration Monitor
 TlsConfiguration.ErrorMessage = Disabling TLS in FIPS mode is not allowed. Either enable StartTls or Require TLS.
+
+passwordTooShortFIPS = Password is too short (< 14 characters)

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeIntegrationTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeIntegrationTest.java
@@ -1,0 +1,28 @@
+package hudson.plugins.active_directory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ActiveDirectoryLoginInFIPSModeIntegrationTest {
+	@Rule
+	public JenkinsRule j = new JenkinsRule();
+
+	@Test(expected = FailingHttpStatusCodeException.class)
+	public void testLoginFailureWithShortPasswordInFIPSmode() throws Exception {
+		ActiveDirectoryDomain activeDirectoryDomain = new ActiveDirectoryDomain("samdom.example.com", "localhost:3268"
+				, "site", "Administrator", "ia4uV1EeKait");
+		List<ActiveDirectoryDomain> domains = new ArrayList<>(1);
+		domains.add(activeDirectoryDomain);
+		ActiveDirectorySecurityRealm activeDirectorySecurityRealm = new ActiveDirectorySecurityRealm(null, domains, null, null, null
+				, null, GroupLookupStrategy.RECURSIVE, false, true, null, true, null, true);
+		j.getInstance().setSecurityRealm(activeDirectorySecurityRealm);
+		// Try to login as Fred with a short password, it will throw an exception
+		j.createWebClient().login("Fred", "ia4uV1EeKait");
+	}
+
+}

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.active_directory;
 import java.lang.reflect.Field;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.acegisecurity.userdetails.UserDetails;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -39,6 +40,12 @@ public class ActiveDirectoryLoginInFIPSModeTest {
 		field.setAccessible(true);
 		field.set(securityRealm, authenticationProvider);
 
+	}
+	
+	@After
+	public void tearDown() {
+		// Clear all static mocks after each test
+		Mockito.clearAllCaches();
 	}
 
 	@Test

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
@@ -1,14 +1,20 @@
 package hudson.plugins.active_directory;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.acegisecurity.userdetails.UserDetails;
+import org.htmlunit.FailingHttpStatusCodeException;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.FlagRule;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mockito;
-
+import org.springframework.security.authentication.AuthenticationServiceException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -45,7 +51,7 @@ public class ActiveDirectoryLoginInFIPSModeTest {
 		String username = "user";
 		String password = "short";
 
-		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+		Exception exception = assertThrows(AuthenticationServiceException.class, () -> {
 			securityRealm.authenticate(username, password);
 		});
 
@@ -67,6 +73,4 @@ public class ActiveDirectoryLoginInFIPSModeTest {
 
 		assertEquals("user",userDetails.getUsername() );
 	}
-
-
 }

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
@@ -1,0 +1,81 @@
+package hudson.plugins.active_directory;
+
+import java.lang.reflect.Field;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.acegisecurity.userdetails.UserDetails;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import jenkins.security.FIPS140;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Author: Nevin Sunny
+ * Date: 30/09/24
+ * Time: 10:13 am
+ */
+public class ActiveDirectoryLoginInFIPSModeTest {
+
+
+	private ActiveDirectorySecurityRealm securityRealm;
+	private AbstractActiveDirectoryAuthenticationProvider authenticationProvider;
+
+	@Before
+	public void setUp() throws NoSuchMethodException, NoSuchFieldException, IllegalAccessException {
+		securityRealm = new ActiveDirectorySecurityRealm("domain", "site"
+				, "bindName", "bindPassword", "server");
+
+		// Create a mock instance of AbstractActiveDirectoryAuthenticationProvider
+		authenticationProvider = Mockito.mock(AbstractActiveDirectoryAuthenticationProvider.class);
+
+		// Use reflection to set the private field
+		Field field = ActiveDirectorySecurityRealm.class.getDeclaredField("authenticationProvider");
+		field.setAccessible(true);
+		field.set(securityRealm, authenticationProvider);
+
+	}
+
+	@Test
+	public void testAuthenticateWithShortPassword() {
+		// Set FIPS to compliant algorithms
+		Mockito.mockStatic(FIPS140.class);
+		when(FIPS140.useCompliantAlgorithms()).thenReturn(true);
+
+		String username = "user";
+		String password = "short";
+
+		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+			securityRealm.authenticate(username, password);
+		});
+
+		assertEquals(Messages.passwordTooShortFIPS(),exception.getMessage() );
+	}
+
+	@Test
+	public void testAuthenticateWithValidPassword() {
+		// Set FIPS to compliant algorithms
+		Mockito.mockStatic(FIPS140.class);
+		when(FIPS140.useCompliantAlgorithms()).thenReturn(true);
+
+		String username = "user";
+		String password = "verylongpassword";
+
+		// Mock the retrieveUser method
+		UserDetails mockUserDetails = Mockito.mock(UserDetails.class);
+		when(mockUserDetails.getUsername()).thenReturn("user");
+		when(authenticationProvider.retrieveUser(anyString(), any(UsernamePasswordAuthenticationToken.class)))
+				.thenReturn(mockUserDetails);
+
+		UserDetails userDetails = securityRealm.authenticate(username, password);
+
+		assertEquals("user",userDetails.getUsername() );
+	}
+
+
+}

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryLoginInFIPSModeTest.java
@@ -3,12 +3,12 @@ package hudson.plugins.active_directory;
 import java.lang.reflect.Field;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.acegisecurity.userdetails.UserDetails;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.FlagRule;
 import org.mockito.Mockito;
 
-import jenkins.security.FIPS140;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -16,16 +16,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-/**
- * Author: Nevin Sunny
- * Date: 30/09/24
- * Time: 10:13 am
- */
 public class ActiveDirectoryLoginInFIPSModeTest {
-
 
 	private ActiveDirectorySecurityRealm securityRealm;
 	private AbstractActiveDirectoryAuthenticationProvider authenticationProvider;
+
+	@ClassRule
+	public static FlagRule<String> fipsSystemPropertyRule =
+			FlagRule.systemProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
 
 	@Before
 	public void setUp() throws NoSuchMethodException, NoSuchFieldException, IllegalAccessException {
@@ -42,18 +40,8 @@ public class ActiveDirectoryLoginInFIPSModeTest {
 
 	}
 	
-	@After
-	public void tearDown() {
-		// Clear all static mocks after each test
-		Mockito.clearAllCaches();
-	}
-
 	@Test
 	public void testAuthenticateWithShortPassword() {
-		// Set FIPS to compliant algorithms
-		Mockito.mockStatic(FIPS140.class);
-		when(FIPS140.useCompliantAlgorithms()).thenReturn(true);
-
 		String username = "user";
 		String password = "short";
 
@@ -66,11 +54,7 @@ public class ActiveDirectoryLoginInFIPSModeTest {
 
 	@Test
 	public void testAuthenticateWithValidPassword() {
-		// Set FIPS to compliant algorithms
-		Mockito.mockStatic(FIPS140.class);
-		when(FIPS140.useCompliantAlgorithms()).thenReturn(true);
-
-		String username = "user";
+        String username = "user";
 		String password = "verylongpassword";
 
 		// Mock the retrieveUser method


### PR DESCRIPTION
If the password is shorted that 14 character and if FIPS mode is enabled , then a andry jenkins erro will be shown  swill be thrown. and login will be blocked 

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/e89fd87c-4d30-4341-b29d-b0808295957c">
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/f6989d0b-ff40-46db-b111-bc7c66edf54c">
