### PR TITLE
[JENKINS-74035] Extract inline script from `ActiveDirectorySecurityRealm/configAdvanced.jelly`

### DIFF
--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/ad-turn-off-autocomplete.js
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/ad-turn-off-autocomplete.js
@@ -1,0 +1,4 @@
+window.addEventListener("DOMContentLoaded", function(event) {
+    document.getElementsByName("_.bindPassword")[0].autocomplete = "off";
+    document.getElementsByName("_.bindName")[0].autocomplete = "off";
+});

--- a/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
+++ b/src/main/resources/hudson/plugins/active_directory/ActiveDirectorySecurityRealm/configAdvanced.jelly
@@ -19,10 +19,5 @@
       <f:repeatableProperty field="environmentProperties" />
     </f:entry>
   </f:advanced>
-	<script type="text/javascript" >
-		document.addEventListener("DOMContentLoaded", function(event) {
-		   document.getElementsByName("_.bindPassword")[0].autocomplete = "off";
-		   document.getElementsByName("_.bindName")[0].autocomplete = "off";
-		});
-	</script>
+  <st:adjunct includes="hudson.plugins.active_directory.ActiveDirectorySecurityRealm.ad-turn-off-autocomplete"/>
 </j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74035

### Testing done
Go to the Global Security Configuration page, select Active Directory as a security realm.
It's a bit weird that that code adds the event listener on `DOMContentLoaded`, because when changing the security realm to Active Directory that event has long been fired. So that code would only be executed when the realm is already set to Active Directory and then you're entering the Global Security Configuration page. Unsure if it's intentional or just a bug. But that behavior is preserved.

[Before the change](https://www.youtube.com/watch?v=XghQv6rED38)
[After the change](https://www.youtube.com/watch?v=JKDSA80e_Jw)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
