### PR TITLE
Fix TODO and rethrow `NamingException` for root cause analysis

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectoryUnixAuthenticationProvider.java
@@ -495,7 +495,7 @@ public class ActiveDirectoryUnixAuthenticationProvider extends AbstractActiveDir
                 throw (AuthenticationException)t;
             }
             if (e.getCause() instanceof NamingException) {
-                throw new NamingException(); // TODO why not re-throw e.getCause() ?
+                throw (NamingException)e.getCause();
             }
             LOGGER.log(Level.SEVERE, "There was a problem caching user "+ username, e);
             throw new CacheAuthenticationException("Authentication failed because there was a problem caching user " +  username, e);


### PR DESCRIPTION
Fix TODO: rethrow NamingException instead of throwing a new, blank NamingException so actual errors can be seen/investigated further

### Testing done

Logs exhibit following before change (for suspected failure to get all AD groups for an SSO authenticated user):
WARNING: Communications issues when trying to authenticate against ${DOMAIN} for user ${USERNAME}
java.naming.NamingException
        at hudson.plugins.active_directory.ActiveDirectoryUnixAuthenticationProvider.retrieveUser(ActiveDirectoryUnixAuthenticationProvider.java:500)

This line is the `throw new` and doesn't include information about actual cause of error.

Logs exhibit following after change (for same attempted login):
WARNING: Communications issues when trying to authenticate against ${DOMAIN} for user ${USERNAME}
javax.naming.NaminException: [LDAP: error code 4 - Sizelimit Exceeded]; remaining name '${DISTINGUISHED_DOMAIN}'
        at java.naming/com.sun.jndi.ldap.LdapCtx.mapErrorCode(LdapCtx.java:3312)
plus 15 other stack entries to investigate branched from the same rest-of-stack as for previous version of error.

This change is to aid in debugging what may well be an error outside the scope of the plugin and is only intended to improve investigation options.  No tests have been modified.

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue