### PR TITLE
Require Jenkins 2.504.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <revision>2.41</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <hpi.bundledArtifacts>active-directory,ado20,com4j</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5054.v620b_5d2b_d5e6</version>
+        <version>5577.vea_979d35b_b_ff</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityFIPSModeShortPasswordTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryJCasCCompatibilityFIPSModeShortPasswordTest.java
@@ -29,7 +29,7 @@ public class ActiveDirectoryJCasCCompatibilityFIPSModeShortPasswordTest {
         String resourceContent = getResourceContent(resourcePath);
         Assert.assertNotNull(resourcePath);
         Assert.assertNotNull(resourceContent);
-        r.then(step -> assertThrows(IllegalStateException.class, () -> configureWithResource(resourcePath)));
+        r.then(step -> assertThrows(ConfiguratorException.class, () -> configureWithResource(resourcePath)));
     }
 
     private String getResourceContent(String resourcePath) throws IOException {


### PR DESCRIPTION
## Require Jenkins 2.504.3 or newer

Fix plugin tests when run with more recent versions of the configuration as code plugin.  Configuration as code plugin now throws a ConfiguratorException instead of an IllegalStateException.

Discovered in plugin BOM pull request:

* https://github.com/jenkinsci/bom/pull/5874

Would like review / FYI from @apuig, @alecharp, @timja

### Testing done

Confirmed that the test fails without the test change and passes with the test change.

Test failure is visible without the test change using:

mvn -Dtest=ActiveDirectoryJCasCCompatibilityFIPSModeShortPasswordTest test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
