### PR TITLE
Update renovate to use Jenkins' parent config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,21 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":semanticCommitsDisabled",
+   "github>jenkinsci/renovate-config",
     "schedule:daily"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "rebaseWhen": "conflicted",
-  "ignorePaths": [
-    "**/node_modules/**",
-    "**/bower_components/**",
-    "**/vendor/**",
-    "**/examples/**",
-    "**/__tests__/**",
-    "**/tests/**",
-    "**/__fixtures__/**"
   ]
 }


### PR DESCRIPTION
The change proposed moves the existing renovate config to our [parent config](https://github.com/jenkinsci/renovate-config) to ease maintenance.

Custom configurations, if available, are still effective.