### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Active Directory plugin for Jenkins
 ===================================
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/active-directory-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/active-directory-plugin/job/master/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Factive-directory-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/active-directory-plugin/job/master/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/active-directory.svg)](https://plugins.jenkins.io/active-directory/)
 [![GitHub release](https://img.shields.io/github/release/jenkinsci/active-directory-plugin.svg?label=changelog)](https://github.com/jenkinsci/active-directory-plugin/releases/latest/)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/active-directory.svg?color=blue)](https://plugins.jenkins.io/active-directory/)


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
