### PR TITLE
Fix LDAP connection leak on failed authentication

### DIFF
--- a/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
+++ b/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java
@@ -709,13 +709,14 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
             String oldName = Thread.currentThread().getName();
             Thread.currentThread().setName("Connecting to "+ldapUrl+" : "+oldName);
             LOGGER.fine("Connecting to " + ldapUrl);
+            LdapContext context = null;
             try {
                 props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
                 props.put(Context.PROVIDER_URL, ldapUrl);
                 props.put("java.naming.ldap.version", "3");
                 customizeLdapProperties(props);
 
-                LdapContext context = new InitialLdapContext(props, null);
+                context = new InitialLdapContext(props, null);
 
                 if (!requireTLS && startTLS) {
                     // try to upgrade to TLS if we can, but failing to do so isn't fatal
@@ -764,6 +765,16 @@ public class ActiveDirectorySecurityRealm extends AbstractPasswordBasedSecurityR
                 context.reconnect(null);
 
                 return context; // worked
+            } catch (Exception e) {
+                // Close the context if reconnect or any other operation failed to prevent LDAP connection leak
+                if (context != null) {
+                    try {
+                        context.close();
+                    } catch (NamingException e1) {
+                        LOGGER.log(Level.FINE, "Failed to close context after bind failure", e1);
+                    }
+                }
+                throw e;
             } finally {
                 Thread.currentThread().setName(oldName);
             }

--- a/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
+++ b/src/test/java/hudson/plugins/active_directory/docker/ActiveDirectoryGenericContainer.java
@@ -7,6 +7,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.PortBinding;
@@ -27,6 +28,8 @@ public class ActiveDirectoryGenericContainer<SELF extends ActiveDirectoryGeneric
                 .withFileFromClasspath("supervisord.conf", "hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/supervisord.conf"));
         // wait for the custom.sh script to complete successfully
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*\\Qexited: custom (exit status 0; expected)\\E.*"));
+        // Samba AD DC provisioning needs SYS_ADMIN to set NT ACLs on sysvol
+        withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withCapAdd(Capability.SYS_ADMIN));
     }
 
     /*

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/Dockerfile
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -13,19 +13,12 @@ RUN apt-get upgrade -y
 RUN apt-get install -y openssh-server supervisor
 RUN mkdir -p /var/run/sshd
 RUN mkdir -p /var/log/supervisor
-RUN sed -ri 's/PermitRootLogin without-password/PermitRootLogin Yes/g' /etc/ssh/sshd_config
 
 # Install bind9 dns server
 RUN apt-get install -y bind9 dnsutils
 ADD named.conf.options /etc/bind/named.conf.options
 
-# Install samba and dependencies to make it an Active Directory Domain Controller
-RUN apt-get install -y curl build-essential libacl1-dev libattr1-dev \
-      libblkid-dev libgnutls-dev libreadline-dev python-dev libpam0g-dev \
-      python-dnspython gdb pkg-config libpopt-dev libldap2-dev \
-      dnsutils libbsd-dev attr krb5-user docbook-xsl libcups2-dev acl python-xattr
-
-RUN apt-get install -y samba smbclient krb5-kdc
+RUN apt-get install -y samba winbind smbclient krb5-kdc
 
 # Install utilities needed for setup
 RUN apt-get install -y expect pwgen

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/custom.sh
@@ -26,7 +26,7 @@ changetype: modify
 replace: sAMAccountName
 sAMAccountName: Rubbles
 EOF
-} && ldapmodify -a -h 127.0.0.1 -p 389 -D "cn=Administrator,cn=Users,dc=samdom,dc=example,dc=com" -w "ia4uV1EeKait" -f file.ldif
+} && ldapmodify -a -H ldap://127.0.0.1:389 -D "cn=Administrator,cn=Users,dc=samdom,dc=example,dc=com" -w "ia4uV1EeKait" -f file.ldif
 
 # add Betty to Rubbles alias
 samba-tool group addmembers Rubbles Betty

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/init.sh
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/init.sh
@@ -29,7 +29,7 @@ appSetup () {
     # Provision Samba
     rm -f /etc/samba/smb.conf
     rm -rf /var/lib/samba/private/*
-    samba-tool domain provision --use-rfc2307 --use-ntvfs --domain=SAMDOM --realm=SAMDOM.EXAMPLE.COM --host-name=dc1 --server-role=dc\
+    samba-tool domain provision --use-rfc2307 --domain=SAMDOM --realm=SAMDOM.EXAMPLE.COM --host-name=dc1 --server-role=dc\
       --dns-backend=BIND9_DLZ --adminpass=$SAMBA_ADMIN_PASSWORD $SAMBA_HOST_IP
     cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
     if [ "${LDAP_ALLOW_INSECURE,,}" == "true" ]; then

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/named.conf.options
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/named.conf.options
@@ -30,6 +30,4 @@ options {
     // DNS dynamic updates via Kerberos
     tkey-gssapi-keytab "/var/lib/samba/private/dns.keytab";
 };
-dlz "AD DNS Zone" {
-    database "dlopen /usr/lib/x86_64-linux-gnu/samba/bind9/dlz_bind9_9.so";
-};
+include "/var/lib/samba/bind-dns/named.conf";

--- a/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/supervisord.conf
+++ b/src/test/resources/hudson/plugins/active_directory/docker/TheFlintstonesTest/TheFlintstones/supervisord.conf
@@ -21,3 +21,5 @@ command=/usr/sbin/rsyslogd -n
 
 [program:custom]
 command=/usr/local/bin/custom.sh
+autorestart=unexpected
+exitcodes=0


### PR DESCRIPTION
Fix LDAP connection leak on failed authentication

LdapContext created in bind() was never closed when
context.reconnect() threw AuthenticationException on wrong password.

Also fix samba test container to accept TLS 1.2 requests (fix linux java25 tests)

### Testing done

Manually tested on a local environment.
Before fix:
- set ldap connection pool size = 1
- try to log in with correct login, incorrect password -> jenkins returns 401 without delay
- try to log in with correct login, correct password -> jenkins hangs trying to get ldap connection from the pool, returns 401 after ~30s delay

After fix:
- set ldap connection pool size = 1
- try to log in with correct login, incorrect password -> jenkins respond with 401
- try to log in with correct login, correct password -> jenkins  respond with 200 without delay

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
