### PR TITLE
Support HTMLUnit 4 and 5 in ActiveDirectoryDomainFIPSEnabledIntegrationTest

### DIFF
--- a/src/test/java/hudson/plugins/active_directory/ActiveDirectoryDomainFIPSEnabledIntegrationTest.java
+++ b/src/test/java/hudson/plugins/active_directory/ActiveDirectoryDomainFIPSEnabledIntegrationTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.logging.Level;
 
 import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.ScriptException;
 import org.htmlunit.html.HtmlButton;
 import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
@@ -21,8 +22,10 @@ import org.jvnet.hudson.test.recipes.LocalData;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,8 +105,11 @@ class ActiveDirectoryDomainFIPSEnabledIntegrationTest {
 		    form.getSelectByName("_.tlsConfiguration").setSelectedAttribute("JDK_TRUSTSTORE", true);
 		}
 
-		// Expect FailingHttpStatusCodeException when finding the "Submit" button and clicking it
-		assertThrows(FailingHttpStatusCodeException.class, () -> getButtonByText(form, button).click());
+		// Expect FailingHttpStatusCodeException (HTMLUnit 4) when finding the "Submit" button and clicking it
+		// Expect ScriptException (HTMLUnit 5) when finding the "Submit" button and clicking it
+		// TODO Remove FailingHttpStatusCodeException.class when plugin pom is newer than 6.2189.x
+		Exception e = assertThrows(Exception.class, () -> getButtonByText(form, button).click());
+		assertThat(e, anyOf(instanceOf(FailingHttpStatusCodeException.class), instanceOf(ScriptException.class)));
 
     }
 


### PR DESCRIPTION
## Support HTMLUnit 4 and 5 in ActiveDirectoryDomainFIPSEnabledIntegrationTest

Jenkins test harness [2571.x](https://github.com/jenkinsci/jenkins-test-harness/releases/tag/2571.v70e084e8616c) upgrades from HTMLUnit 4 to HTMLUnit 5.

That upgrade provides new capabilties, but also changes the exception that is thrown in the affected assertion.  The test is adapted to accept either exception so that the test won't block a future upgrade of the parent pom.

Uses HTMLUnit 5.0.0 as included in pull request:

* https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/209

HTMLUnit 5.0.0 blog post:

* https://htmlunit.github.io/htmlunit-blog/2026/05/24/release-5-0-0.html

HTMLUnit 5.0.0 release notes:

* https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/209

No attempt has been made to use the new features of HTMLUnit 5.0.0.

### Testing done

* Confirmed that the modified test passes with both the current parent pom and when the Jenkins test harness 2571.x is used.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
