### PR TITLE
Rely on jenkinsci organization release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,0 @@
-
-_extends: github:jenkinsci/.github:/.github/release-drafter.yml
-name-template: v$NEXT_MINOR_VERSION
-tag-template: active-directory-$NEXT_MINOR_VERSION


### PR DESCRIPTION
Hello :wave:

I noticed that merging https://github.com/jenkinsci/active-directory-plugin/pull/707 didn't produce a new release, despite the `enhancement` label being added to the PR.

Apparently this problem comes from changes in release-drafter, as highlighted in similar PRs like https://github.com/jenkinsci/lib-durable-task/pull/167.

Proposing this PR to bring back automated releases.
